### PR TITLE
Add production packaging, release workflow, and installer scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache-dependency-path: backend/go.sum
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Embed frontend assets
+        run: |
+          rm -rf backend/cmd/server/web/dist
+          mkdir -p backend/cmd/server/web
+          cp -R frontend/dist backend/cmd/server/web/dist
+
+      - name: Build Linux binaries
+        working-directory: backend
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+          mkdir -p ../dist
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o ../dist/3m-ui-linux-amd64 ./cmd/server
+          CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -trimpath -ldflags "-s -w" -o ../dist/3m-ui-linux-arm64 ./cmd/server
+          CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc go build -trimpath -ldflags "-s -w" -o ../dist/3m-ui-linux-armv7 ./cmd/server
+
+      - name: Add deployment scripts
+        run: cp scripts/install.sh scripts/update.sh scripts/uninstall.sh dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('manual-{0}', github.run_number) }}
+          name: ${{ github.ref_type == 'tag' && github.ref_name || format('Manual build {0}', github.run_number) }}
+          files: |
+            dist/3m-ui-linux-amd64
+            dist/3m-ui-linux-arm64
+            dist/3m-ui-linux-armv7
+            dist/install.sh
+            dist/update.sh
+            dist/uninstall.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+APP_NAME := 3m-ui
+BACKEND_DIR := backend
+FRONTEND_DIR := frontend
+DIST_DIR := dist
+
+.PHONY: build build-linux release clean
+
+build:
+	cd $(FRONTEND_DIR) && pnpm build
+	rm -rf $(BACKEND_DIR)/cmd/server/web/dist
+	cp -R $(FRONTEND_DIR)/dist $(BACKEND_DIR)/cmd/server/web/dist
+	cd $(BACKEND_DIR) && go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME) ./cmd/server
+
+build-linux:
+	mkdir -p $(DIST_DIR)
+	cd $(BACKEND_DIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME)-linux-amd64 ./cmd/server
+	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME)-linux-arm64 ./cmd/server
+	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME)-linux-armv7 ./cmd/server
+
+release: clean build build-linux
+	cp scripts/install.sh scripts/update.sh scripts/uninstall.sh $(DIST_DIR)/
+
+clean:
+	rm -rf $(DIST_DIR)

--- a/README.md
+++ b/README.md
@@ -108,3 +108,94 @@ cd frontend
 pnpm build
 ```
 This generates the static bundle in `frontend/dist` which can be served by any static asset host or backend handler.
+
+---
+
+## Production Installation
+
+3m-ui is distributed as a single Linux server binary with the built frontend embedded into the Go executable. Official release assets include Linux binaries for `amd64`, `arm64`, and `armv7`, plus installer, updater, and uninstaller scripts.
+
+### Supported Platforms
+
+- Debian and Ubuntu with systemd
+- Alpine Linux with OpenRC
+- CPU architectures: `amd64`, `arm64`, `armv7`
+
+### Install
+
+Run the installer as root on the target server:
+
+```bash
+curl -fsSL https://github.com/dzx941/3m-ui/releases/latest/download/install.sh | sh
+```
+
+The installer detects the OS, CPU architecture, and init system, downloads the matching release binary from `https://github.com/dzx941/3m-ui/releases`, writes the service definition, enables the service, and starts 3m-ui automatically.
+
+After installation, open:
+
+```text
+http://SERVER_IP:8080/
+```
+
+### Upgrade
+
+Upgrade keeps the database, user data, Mihomo configuration files, and existing application configuration. It backs up `/etc/3m-ui` before replacing the binary.
+
+```bash
+curl -fsSL https://github.com/dzx941/3m-ui/releases/latest/download/update.sh | sh
+```
+
+### Uninstall
+
+Remove the binary, service, configuration, and logs while keeping persistent data in `/var/lib/3m-ui`:
+
+```bash
+curl -fsSL https://github.com/dzx941/3m-ui/releases/latest/download/uninstall.sh | sh
+```
+
+Remove all data as well:
+
+```bash
+curl -fsSL https://github.com/dzx941/3m-ui/releases/latest/download/uninstall.sh -o uninstall.sh
+sh uninstall.sh --purge
+```
+
+### Production Directory Layout
+
+```text
+/usr/local/bin/3m-ui       # Installed server binary
+/etc/3m-ui/config.yaml     # Application configuration
+/var/lib/3m-ui/            # Persistent application data
+/var/lib/3m-ui/3m-ui.db    # SQLite database
+/var/lib/3m-ui/mihomo/     # Generated Mihomo configuration files
+/var/log/3m-ui/            # Log directory reserved for deployments
+```
+
+### Service Management
+
+systemd:
+
+```bash
+systemctl status 3m-ui
+systemctl restart 3m-ui
+```
+
+OpenRC:
+
+```bash
+rc-service 3m-ui status
+rc-service 3m-ui restart
+```
+
+## Release and Packaging
+
+The release pipeline runs from `.github/workflows/release.yml` on `v*` tags and manual dispatch. It builds the frontend with pnpm, copies `frontend/dist` into the backend embed directory, cross-compiles Linux binaries into `dist/`, copies deployment scripts, and publishes all artifacts to a GitHub Release.
+
+Local packaging commands:
+
+```bash
+make build        # Build embedded frontend and host binary into dist/3m-ui
+make build-linux  # Build Linux release binaries
+make release      # Clean, build, cross-compile, and copy scripts
+make clean        # Remove dist/
+```

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/dzx941/3m-ui/backend/internal/config"
+	"github.com/dzx941/3m-ui/backend/internal/database"
+	"github.com/dzx941/3m-ui/backend/internal/listener"
+	"github.com/dzx941/3m-ui/backend/internal/mihomo"
+	"github.com/dzx941/3m-ui/backend/internal/node"
+	"github.com/dzx941/3m-ui/backend/internal/router"
+	"github.com/dzx941/3m-ui/backend/internal/security"
+	"github.com/dzx941/3m-ui/backend/internal/traffic"
+	"github.com/dzx941/3m-ui/backend/internal/user"
+	"github.com/gin-gonic/gin"
+)
+
+//go:embed web/dist/*
+var frontendFiles embed.FS
+
+func main() {
+	configPath := defaultConfigPath()
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	if _, err := database.InitDB(cfg.Database.Path); err != nil {
+		log.Fatalf("initialize database: %v", err)
+	}
+	security.InitCredentialKey(cfg.Security.CredentialKey)
+	mihomo.InitService(cfg)
+	listener.InitService(database.GlobalDB, cfg.Mihomo.Config)
+	node.InitService(database.GlobalDB, cfg.Mihomo.Config)
+	user.InitService(database.GlobalDB)
+	traffic.InitGlobalService()
+
+	r := router.SetupRouter(cfg)
+	mountFrontend(r)
+
+	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+	log.Printf("3m-ui listening on %s", addr)
+	if err := r.Run(addr); err != nil {
+		log.Fatalf("run server: %v", err)
+	}
+}
+
+func defaultConfigPath() string {
+	if value := os.Getenv("3M_UI_CONFIG"); value != "" {
+		return value
+	}
+	if _, err := os.Stat("/etc/3m-ui/config.yaml"); err == nil {
+		return "/etc/3m-ui/config.yaml"
+	}
+	return "backend/config/config.yaml"
+}
+
+func mountFrontend(r *gin.Engine) {
+	staticFS, err := fs.Sub(frontendFiles, "web/dist")
+	if err != nil {
+		log.Printf("frontend assets unavailable: %v", err)
+		return
+	}
+
+	r.NoRoute(func(c *gin.Context) {
+		if filepath.Ext(c.Request.URL.Path) == "" {
+			c.FileFromFS("index.html", http.FS(staticFS))
+			return
+		}
+		c.FileFromFS(c.Request.URL.Path[1:], http.FS(staticFS))
+	})
+}

--- a/backend/cmd/server/web/dist/index.html
+++ b/backend/cmd/server/web/dist/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="UTF-8"><title>3m-ui</title></head><body><div id="root">3m-ui frontend assets were not embedded in this build.</div></body></html>

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/dzx941/3m-ui/backend
 
-go 1.23
+go 1.25.0
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/backend/internal/database/models/proxy_user.go
+++ b/backend/internal/database/models/proxy_user.go
@@ -13,18 +13,18 @@ type ProxyUser struct {
 
 	Username string `gorm:"size:100;not null;uniqueIndex" json:"username"`
 	// PasswordEncrypted contains an AES-GCM encrypted password. It is never serialized to API responses.
-	PasswordEncrypted string    `gorm:"type:text" json:"-"`
-	UUID              string    `gorm:"size:64;not null;uniqueIndex" json:"-"`
-	TrafficLimit      int64     `gorm:"not null;default:0" json:"traffic_limit"`
-	TrafficUsed       int64     `gorm:"not null;default:0" json:"traffic_used"`
+	PasswordEncrypted string `gorm:"type:text" json:"-"`
+	UUID              string `gorm:"size:64;not null;uniqueIndex" json:"-"`
+	TrafficLimit      int64  `gorm:"not null;default:0" json:"traffic_limit"`
+	TrafficUsed       int64  `gorm:"not null;default:0" json:"traffic_used"`
 	// UploadBytes/DownloadBytes are cumulative counters split by direction.
 	// TrafficUsed (above) remains the single source of truth for quota
 	// enforcement and equals UploadBytes+DownloadBytes over time.
-	UploadBytes   int64      `gorm:"not null;default:0" json:"upload_bytes"`
-	DownloadBytes int64      `gorm:"not null;default:0" json:"download_bytes"`
+	UploadBytes   int64 `gorm:"not null;default:0" json:"upload_bytes"`
+	DownloadBytes int64 `gorm:"not null;default:0" json:"download_bytes"`
 	// LastSeen is updated whenever the traffic collector observes an active
 	// Mihomo connection attributable to this user. Nil means never seen.
-	LastSeen   *time.Time `json:"last_seen"`
+	LastSeen *time.Time `json:"last_seen"`
 	// Online reflects whether the user had at least one active connection
 	// during the most recent traffic collection tick.
 	Online     bool      `gorm:"not null;default:false" json:"online"`

--- a/backend/internal/database/models/traffic_record.go
+++ b/backend/internal/database/models/traffic_record.go
@@ -7,8 +7,8 @@ import "gorm.io/gorm"
 type TrafficRecord struct {
 	gorm.Model
 
-	ProxyUserID uint `gorm:"index;not null" json:"proxy_user_id"`
-	UploadBytes int64 `gorm:"not null;default:0" json:"upload_bytes"`
+	ProxyUserID   uint  `gorm:"index;not null" json:"proxy_user_id"`
+	UploadBytes   int64 `gorm:"not null;default:0" json:"upload_bytes"`
 	DownloadBytes int64 `gorm:"not null;default:0" json:"download_bytes"`
-	Online bool `gorm:"default:false" json:"online"`
+	Online        bool  `gorm:"default:false" json:"online"`
 }

--- a/backend/internal/mihomo/api/client.go
+++ b/backend/internal/mihomo/api/client.go
@@ -16,8 +16,8 @@ type Client struct {
 func NewClient(baseURL, secret string) *Client {
 	return &Client{
 		BaseURL: baseURL,
-		Secret: secret,
-		HTTP: &http.Client{Timeout: 5 * time.Second},
+		Secret:  secret,
+		HTTP:    &http.Client{Timeout: 5 * time.Second},
 	}
 }
 

--- a/backend/internal/mihomo/api/types.go
+++ b/backend/internal/mihomo/api/types.go
@@ -6,8 +6,8 @@ type Traffic struct {
 }
 
 type Connections struct {
-	DownloadTotal int64 `json:"downloadTotal"`
-	UploadTotal   int64 `json:"uploadTotal"`
+	DownloadTotal int64        `json:"downloadTotal"`
+	UploadTotal   int64        `json:"uploadTotal"`
 	Connections   []Connection `json:"connections"`
 }
 

--- a/backend/internal/mihomo/process.go
+++ b/backend/internal/mihomo/process.go
@@ -14,12 +14,12 @@ import (
 )
 
 type ProcessManager struct {
-	mu         sync.Mutex
-	cmd        *exec.Cmd
-	pid        int
-	startTime  time.Time
-	binaryPath string
-	configPath string
+	mu          sync.Mutex
+	cmd         *exec.Cmd
+	pid         int
+	startTime   time.Time
+	binaryPath  string
+	configPath  string
 	isSimulated bool
 }
 

--- a/backend/internal/subscription/api.go
+++ b/backend/internal/subscription/api.go
@@ -34,17 +34,17 @@ func RegisterRoutes(r *gin.RouterGroup) {
 
 	r.POST("/subscriptions", func(c *gin.Context) {
 		var req struct {
-			UserID uint `json:"user_id"`
+			UserID uint   `json:"user_id"`
 			Format string `json:"format"`
 		}
 		if c.ShouldBindJSON(&req) != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error":"invalid request"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 			return
 		}
 		s := NewService(database.GlobalDB)
 		sub, err := s.Create(req.UserID, strings.ToLower(req.Format))
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error":err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		c.JSON(http.StatusOK, sub)

--- a/backend/internal/subscription/generator.go
+++ b/backend/internal/subscription/generator.go
@@ -47,12 +47,12 @@ func (g *Generator) Generate(userID uint) ([]byte, error) {
 		_ = json.Unmarshal([]byte(l.Config), &extra)
 
 		p := ClientProxy{
-			Name: l.Name,
-			Type: l.Protocol,
+			Name:   l.Name,
+			Type:   l.Protocol,
 			Server: l.BindAddress,
-			Port: l.Port,
-			TLS: l.TLS,
-			UDP: l.UDP,
+			Port:   l.Port,
+			TLS:    l.TLS,
+			UDP:    l.UDP,
 		}
 
 		if v, ok := extra["password"].(string); ok {
@@ -67,11 +67,11 @@ func (g *Generator) Generate(userID uint) ([]byte, error) {
 
 	cfg := map[string]interface{}{
 		"mixed-port": 7890,
-		"proxies": proxies,
+		"proxies":    proxies,
 		"proxy-groups": []interface{}{
 			map[string]interface{}{
-				"name": "AUTO",
-				"type": "select",
+				"name":    "AUTO",
+				"type":    "select",
 				"proxies": []string{"DIRECT"},
 			},
 		},

--- a/backend/internal/subscription/service.go
+++ b/backend/internal/subscription/service.go
@@ -37,7 +37,7 @@ func (s *Service) Create(userID uint, format string) (*models.Subscription, erro
 
 	sub := &models.Subscription{
 		UserID: userID,
-		Token: token,
+		Token:  token,
 		Format: format,
 	}
 

--- a/backend/internal/system/metrics.go
+++ b/backend/internal/system/metrics.go
@@ -32,7 +32,7 @@ func GetSystemStats() *SystemStats {
 	vMem, err := mem.VirtualMemory()
 	if err == nil {
 		memoryInfo = MemoryInfo{
-			Used:    float64(vMem.Used) / (1024 * 1024), // to MB
+			Used:    float64(vMem.Used) / (1024 * 1024),  // to MB
 			Total:   float64(vMem.Total) / (1024 * 1024), // to MB
 			Percent: math.Round(vMem.UsedPercent*10) / 10,
 		}
@@ -43,7 +43,7 @@ func GetSystemStats() *SystemStats {
 	dUsage, err := disk.Usage("/")
 	if err == nil {
 		diskInfo = DiskInfo{
-			Used:    float64(dUsage.Used) / (1024 * 1024 * 1024), // to GB
+			Used:    float64(dUsage.Used) / (1024 * 1024 * 1024),  // to GB
 			Total:   float64(dUsage.Total) / (1024 * 1024 * 1024), // to GB
 			Percent: math.Round(dUsage.UsedPercent*10) / 10,
 		}

--- a/backend/internal/traffic/service.go
+++ b/backend/internal/traffic/service.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Service struct {
-	mu sync.Mutex
-	last Snapshot
+	mu       sync.Mutex
+	last     Snapshot
 	lastTime time.Time
 }
 
@@ -33,9 +33,9 @@ func (s *Service) Update(totalUpload, totalDownload int64, connections int) Snap
 	now := time.Now()
 	seconds := now.Sub(s.lastTime).Seconds()
 	result := Snapshot{
-		UploadBytes: totalUpload,
+		UploadBytes:   totalUpload,
 		DownloadBytes: totalDownload,
-		Connections: connections,
+		Connections:   connections,
 	}
 
 	if seconds > 0 {

--- a/backend/internal/traffic/user.go
+++ b/backend/internal/traffic/user.go
@@ -21,10 +21,10 @@ func NewUserService(db *gorm.DB) *UserService {
 // UploadBytes, DownloadBytes) plus LastSeen/Online when online is true.
 func (s *UserService) AddSample(userID uint, up, down int64, online bool) error {
 	record := &models.TrafficRecord{
-		ProxyUserID: userID,
-		UploadBytes: up,
+		ProxyUserID:   userID,
+		UploadBytes:   up,
 		DownloadBytes: down,
-		Online: online,
+		Online:        online,
 	}
 	if err := s.db.Create(record).Error; err != nil {
 		return err

--- a/backend/internal/user/user_test.go
+++ b/backend/internal/user/user_test.go
@@ -12,27 +12,43 @@ import (
 func TestActiveCredentialsFiltering(t *testing.T) {
 	security.InitCredentialKey("test-secret")
 	db, err := database.InitDB(t.TempDir() + "/test.db")
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	InitService(db)
 
 	l1 := models.Listener{Name: "ss", Protocol: "shadowsocks", Port: 8388, Enabled: true}
-	if err := db.Create(&l1).Error; err != nil { t.Fatal(err) }
+	if err := db.Create(&l1).Error; err != nil {
+		t.Fatal(err)
+	}
 
 	active, err := GlobalService.Create(CreateInput{Username: "active", Password: "p1"})
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	expiredAt := time.Now().Add(-time.Hour)
 	expired, err := GlobalService.Create(CreateInput{Username: "expired", Password: "p2", ExpireTime: &expiredAt})
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	limited, err := GlobalService.Create(CreateInput{Username: "limited", Password: "p3", TrafficLimit: 10})
-	if err != nil { t.Fatal(err) }
-	if err := db.Model(limited).Update("traffic_used", int64(10)).Error; err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(limited).Update("traffic_used", int64(10)).Error; err != nil {
+		t.Fatal(err)
+	}
 
 	for _, id := range []uint{active.ID, expired.ID, limited.ID} {
-		if err := db.Create(&models.ListenerUser{ListenerID: l1.ID, ProxyUserID: id}).Error; err != nil { t.Fatal(err) }
+		if err := db.Create(&models.ListenerUser{ListenerID: l1.ID, ProxyUserID: id}).Error; err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	creds, err := GlobalService.ActiveCredentialsByListener()
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(creds[l1.ID]) != 1 || creds[l1.ID][0].Password != "p1" {
 		t.Fatalf("expected only active user credential, got %#v", creds[l1.ID])
 	}
@@ -41,20 +57,34 @@ func TestActiveCredentialsFiltering(t *testing.T) {
 func TestBindListenersIsReplacement(t *testing.T) {
 	security.InitCredentialKey("test-secret")
 	db, err := database.InitDB(t.TempDir() + "/test.db")
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	InitService(db)
 
 	u, err := GlobalService.Create(CreateInput{Username: "bind-user", Password: "p"})
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	var listeners []models.Listener
 	for i := 0; i < 3; i++ {
 		l := models.Listener{Name: "n", Protocol: "trojan", Port: 10000 + i, Enabled: true}
-		if err := db.Create(&l).Error; err != nil { t.Fatal(err) }
+		if err := db.Create(&l).Error; err != nil {
+			t.Fatal(err)
+		}
 		listeners = append(listeners, l)
 	}
-	if err := GlobalService.BindListeners(u.ID, []uint{listeners[0].ID, listeners[1].ID}); err != nil { t.Fatal(err) }
-	if err := GlobalService.BindListeners(u.ID, []uint{listeners[2].ID}); err != nil { t.Fatal(err) }
+	if err := GlobalService.BindListeners(u.ID, []uint{listeners[0].ID, listeners[1].ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := GlobalService.BindListeners(u.ID, []uint{listeners[2].ID}); err != nil {
+		t.Fatal(err)
+	}
 	got, err := GlobalService.GetListeners(u.ID)
-	if err != nil { t.Fatal(err) }
-	if len(got) != 1 || got[0].ID != listeners[2].ID { t.Fatalf("expected replacement binding, got %#v", got) }
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != listeners[2].ID {
+		t.Fatalf("expected replacement binding, got %#v", got)
+	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="dzx941/3m-ui"
+INSTALL_DIR="/usr/local/bin"
+BIN_PATH="$INSTALL_DIR/3m-ui"
+CONFIG_DIR="/etc/3m-ui"
+DATA_DIR="/var/lib/3m-ui"
+LOG_DIR="/var/log/3m-ui"
+SERVICE_NAME="3m-ui"
+
+need_root() { [ "$(id -u)" -eq 0 ] || { echo "Please run as root." >&2; exit 1; }; }
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+arch_name() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo amd64 ;;
+    aarch64|arm64) echo arm64 ;;
+    armv7l|armv7*) echo armv7 ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+}
+
+init_system() {
+  if command_exists systemctl && [ -d /run/systemd/system ]; then echo systemd; return; fi
+  if command_exists rc-service; then echo openrc; return; fi
+  echo "Unsupported init system. systemd or OpenRC is required." >&2; exit 1
+}
+
+latest_url() {
+  arch="$1"
+  echo "https://github.com/$REPO/releases/latest/download/3m-ui-linux-$arch"
+}
+
+download() {
+  url="$1"; dest="$2"
+  if command_exists curl; then curl -fsSL "$url" -o "$dest"; elif command_exists wget; then wget -qO "$dest" "$url"; else echo "curl or wget is required." >&2; exit 1; fi
+}
+
+write_config() {
+  [ -f "$CONFIG_DIR/config.yaml" ] && return
+  jwt_secret="$(date +%s | sha256sum | awk '{print $1}')"
+  cred_key="$(date +%s%N | sha256sum | awk '{print $1}')"
+  cat > "$CONFIG_DIR/config.yaml" <<CFG
+server:
+  port: 8080
+  mode: "release"
+
+database:
+  path: "$DATA_DIR/3m-ui.db"
+
+jwt:
+  secret: "$jwt_secret"
+security:
+  credential_key: "$cred_key"
+
+mihomo:
+  binary: "/usr/local/bin/mihomo"
+  config: "$DATA_DIR/mihomo/config.yaml"
+CFG
+}
+
+install_systemd() {
+  cat > /etc/systemd/system/$SERVICE_NAME.service <<EOF2
+[Unit]
+Description=3m-ui server panel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$BIN_PATH
+Restart=on-failure
+RestartSec=5s
+Environment=3M_UI_CONFIG=$CONFIG_DIR/config.yaml
+WorkingDirectory=$DATA_DIR
+
+[Install]
+WantedBy=multi-user.target
+EOF2
+  systemctl daemon-reload
+  systemctl enable --now $SERVICE_NAME
+}
+
+install_openrc() {
+  cat > /etc/init.d/$SERVICE_NAME <<EOF2
+#!/sbin/openrc-run
+name="3m-ui"
+description="3m-ui server panel"
+command="$BIN_PATH"
+command_background="yes"
+pidfile="/run/3m-ui.pid"
+directory="$DATA_DIR"
+export 3M_UI_CONFIG="$CONFIG_DIR/config.yaml"
+depend() { need net; }
+EOF2
+  chmod +x /etc/init.d/$SERVICE_NAME
+  rc-update add $SERVICE_NAME default
+  rc-service $SERVICE_NAME start
+}
+
+need_root
+mkdir -p "$INSTALL_DIR" "$CONFIG_DIR" "$DATA_DIR/mihomo" "$LOG_DIR"
+arch="$(arch_name)"
+tmp="$(mktemp)"
+download "$(latest_url "$arch")" "$tmp"
+install -m 0755 "$tmp" "$BIN_PATH"
+rm -f "$tmp"
+write_config
+case "$(init_system)" in systemd) install_systemd ;; openrc) install_openrc ;; esac
+echo "3m-ui installed. Open http://SERVER_IP:8080/"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+BIN_PATH="/usr/local/bin/3m-ui"; CONFIG_DIR="/etc/3m-ui"; DATA_DIR="/var/lib/3m-ui"; LOG_DIR="/var/log/3m-ui"; SERVICE_NAME="3m-ui"; PURGE=0
+[ "${1:-}" = "--purge" ] && PURGE=1
+[ "$(id -u)" -eq 0 ] || { echo "Please run as root." >&2; exit 1; }
+printf "Uninstall 3m-ui? This removes the service, binary, and configs. [y/N] "; read ans
+case "$ans" in y|Y|yes|YES) ;; *) echo "Aborted."; exit 0;; esac
+if command -v systemctl >/dev/null 2>&1 && [ -f /etc/systemd/system/$SERVICE_NAME.service ]; then systemctl disable --now $SERVICE_NAME || true; rm -f /etc/systemd/system/$SERVICE_NAME.service; systemctl daemon-reload || true; fi
+if command -v rc-service >/dev/null 2>&1 && [ -f /etc/init.d/$SERVICE_NAME ]; then rc-service $SERVICE_NAME stop || true; rc-update del $SERVICE_NAME default || true; rm -f /etc/init.d/$SERVICE_NAME; fi
+rm -f "$BIN_PATH"; rm -rf "$CONFIG_DIR" "$LOG_DIR"
+if [ "$PURGE" -eq 1 ]; then rm -rf "$DATA_DIR"; echo "3m-ui uninstalled and data purged."; else echo "3m-ui uninstalled. Data kept at $DATA_DIR (use --purge to remove it)."; fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+REPO="dzx941/3m-ui"; BIN_PATH="/usr/local/bin/3m-ui"; CONFIG_DIR="/etc/3m-ui"; DATA_DIR="/var/lib/3m-ui"; SERVICE_NAME="3m-ui"
+[ "$(id -u)" -eq 0 ] || { echo "Please run as root." >&2; exit 1; }
+[ -x "$BIN_PATH" ] || { echo "3m-ui is not installed at $BIN_PATH" >&2; exit 1; }
+command_exists(){ command -v "$1" >/dev/null 2>&1; }
+arch_name(){ case "$(uname -m)" in x86_64|amd64) echo amd64;; aarch64|arm64) echo arm64;; armv7l|armv7*) echo armv7;; *) echo "Unsupported architecture" >&2; exit 1;; esac; }
+download(){ if command_exists curl; then curl -fsSL "$1" -o "$2"; elif command_exists wget; then wget -qO "$2" "$1"; else echo "curl or wget is required." >&2; exit 1; fi; }
+stop_service(){ if command_exists systemctl && [ -f /etc/systemd/system/$SERVICE_NAME.service ]; then systemctl stop $SERVICE_NAME; elif command_exists rc-service && [ -f /etc/init.d/$SERVICE_NAME ]; then rc-service $SERVICE_NAME stop; fi; }
+start_service(){ if command_exists systemctl && [ -f /etc/systemd/system/$SERVICE_NAME.service ]; then systemctl start $SERVICE_NAME; elif command_exists rc-service && [ -f /etc/init.d/$SERVICE_NAME ]; then rc-service $SERVICE_NAME start; fi; }
+backup_dir="$DATA_DIR/backups/$(date +%Y%m%d%H%M%S)"; mkdir -p "$backup_dir"; [ -d "$CONFIG_DIR" ] && cp -a "$CONFIG_DIR" "$backup_dir/config"
+tmp="$(mktemp)"; download "https://github.com/$REPO/releases/latest/download/3m-ui-linux-$(arch_name)" "$tmp"
+stop_service
+install -m 0755 "$tmp" "$BIN_PATH"; rm -f "$tmp"
+start_service
+echo "3m-ui updated. Config backup: $backup_dir"


### PR DESCRIPTION
### Motivation

- Make 3m-ui installable and distributable as a production server panel with embedded frontend and prebuilt Linux binaries.
- Provide a reproducible CI/CD pipeline that builds frontend assets, embeds them in the Go server, cross-compiles Linux binaries, and publishes release artifacts.
- Provide simple on-host installation, upgrade and uninstall flows for common Linux distributions and init systems.
- Provide convenient local packaging targets (`make`) and documentation for operators.

### Description

- Added a GitHub Actions release workflow at `.github/workflows/release.yml` that builds the frontend with `pnpm`, copies `frontend/dist` into `backend/cmd/server/web/dist`, cross-compiles Linux binaries (`amd64`, `arm64`, `armv7`), stages `install.sh`, `update.sh`, and `uninstall.sh`, and publishes a GitHub Release with those artifacts. 
- Added a production server entrypoint `backend/cmd/server/main.go` which embeds frontend assets via `//go:embed web/dist/*`, initializes configuration and services (`database`, `security`, `mihomo`, `listener/node/user`, `traffic`), and mounts the embedded UI. 
- Added installer/updater/uninstaller scripts under `scripts/` implementing architecture detection, release download from `https://github.com/dzx941/3m-ui/releases`, service installation/management for both `systemd` and OpenRC, configuration and data directory layout, and `--purge` support for `uninstall.sh`.
- Added a `Makefile` with `make build`, `make build-linux`, `make release`, and `make clean` targets to build the embedded binary locally, cross-compile Linux release binaries, and package the release artifacts.
- Updated `README.md` with production installation, upgrade, uninstall instructions, supported platforms, and directory layout documentation. 
- Bumped backend `go` version in `backend/go.mod` to `1.25.0` to match the build expectations.

### Testing

- Ran `go fmt ./...` in `backend` successfully. 
- Ran `go vet ./...` in `backend` successfully. 
- Ran `go test ./...` in `backend` and observed most packages passed but one unit test failed: `backend/internal/user TestBindListenersIsReplacement` (investigate existing test expectations). 
- Built the frontend with `pnpm build` in `frontend` successfully and verified `frontend/dist` was produced and copied to `backend/cmd/server/web/dist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a798a5f44832ea8cbe733d6079881)