### PR TITLE
Fix BindListeners replacement semantics and soft-delete handling

### DIFF
--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -148,19 +148,47 @@ func (s *Service) BindListeners(userID uint, listenerIDs []uint) error {
 		if err := tx.First(&user, userID).Error; err != nil {
 			return err
 		}
-		if len(listenerIDs) > 0 {
+
+		desired := make([]uint, 0, len(listenerIDs))
+		seen := make(map[uint]struct{}, len(listenerIDs))
+		for _, listenerID := range listenerIDs {
+			if _, ok := seen[listenerID]; ok {
+				continue
+			}
+			seen[listenerID] = struct{}{}
+			desired = append(desired, listenerID)
+		}
+
+		if len(desired) > 0 {
 			var count int64
-			if err := tx.Model(&models.Listener{}).Where("id IN ?", listenerIDs).Count(&count).Error; err != nil {
+			if err := tx.Model(&models.Listener{}).Where("id IN ?", desired).Count(&count).Error; err != nil {
 				return err
 			}
-			if count != int64(len(listenerIDs)) {
+			if count != int64(len(desired)) {
 				return errors.New("one or more listener ids do not exist")
 			}
-		}
-		if err := tx.Where("proxy_user_id = ?", userID).Delete(&models.ListenerUser{}).Error; err != nil {
+
+			if err := tx.Where("proxy_user_id = ? AND listener_id NOT IN ?", userID, desired).Delete(&models.ListenerUser{}).Error; err != nil {
+				return err
+			}
+		} else if err := tx.Where("proxy_user_id = ?", userID).Delete(&models.ListenerUser{}).Error; err != nil {
 			return err
 		}
-		for _, listenerID := range listenerIDs {
+
+		for _, listenerID := range desired {
+			var binding models.ListenerUser
+			result := tx.Unscoped().Where("listener_id = ? AND proxy_user_id = ?", listenerID, userID).Find(&binding)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected > 0 {
+				if binding.DeletedAt.Valid {
+					if err := tx.Unscoped().Model(&binding).Update("deleted_at", nil).Error; err != nil {
+						return err
+					}
+				}
+				continue
+			}
 			if err := tx.Create(&models.ListenerUser{ListenerID: listenerID, ProxyUserID: userID}).Error; err != nil {
 				return err
 			}
@@ -171,8 +199,8 @@ func (s *Service) BindListeners(userID uint, listenerIDs []uint) error {
 
 func (s *Service) GetListeners(userID uint) ([]models.Listener, error) {
 	var listeners []models.Listener
-	err := s.db.Table("listeners").
-		Joins("JOIN listener_users ON listener_users.listener_id = listeners.id").
+	err := s.db.Model(&models.Listener{}).
+		Joins("JOIN listener_users ON listener_users.listener_id = listeners.id AND listener_users.deleted_at IS NULL").
 		Where("listener_users.proxy_user_id = ?", userID).
 		Order("listeners.id").
 		Find(&listeners).Error

--- a/backend/internal/user/user_test.go
+++ b/backend/internal/user/user_test.go
@@ -87,4 +87,22 @@ func TestBindListenersIsReplacement(t *testing.T) {
 	if len(got) != 1 || got[0].ID != listeners[2].ID {
 		t.Fatalf("expected replacement binding, got %#v", got)
 	}
+
+	if err := GlobalService.BindListeners(u.ID, []uint{listeners[2].ID, listeners[2].ID, listeners[0].ID}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = GlobalService.GetListeners(u.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].ID != listeners[0].ID || got[1].ID != listeners[2].ID {
+		t.Fatalf("expected deduplicated replacement binding, got %#v", got)
+	}
+	var rows []models.ListenerUser
+	if err := db.Unscoped().Where("proxy_user_id = ?", u.ID).Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected soft-deleted bindings to be reused without duplicates, got %#v", rows)
+	}
 }


### PR DESCRIPTION
### Motivation
- The `TestBindListenersIsReplacement` unit test was failing due to interaction between soft-delete semantics on `listener_users` and how bindings were replaced and queried, so `BindListeners` must continue to perform true replacement while avoiding duplicate join rows and preserving soft-delete history.

### Description
- Deduplicate requested listener IDs early and validate only the unique `desired` IDs against the `listeners` table to avoid repeated work and erroneous validation.
- Change delete behavior to remove only bindings not present in the new `desired` set, preserving and restoring soft-deleted rows for rebindings instead of creating duplicates.
- When creating bindings, use an `Unscoped().Find` to detect existing (including soft-deleted) `ListenerUser` rows and restore them by clearing `deleted_at` when present, avoiding duplicate join records.
- Update `GetListeners` SQL to join with `listener_users.deleted_at IS NULL` so soft-deleted bindings are excluded from returned results.
- Extend `TestBindListenersIsReplacement` to exercise duplicate IDs in input, rebind previously soft-deleted entries, and assert that historic (soft-deleted) rows are reused without producing duplicate `ListenerUser` records.

### Testing
- Ran the focused test: `cd backend && go test ./internal/user -run TestBindListenersIsReplacement -v`, which passed.
- Ran the full backend test suite: `cd backend && go test ./...`, which passed for all packages.
- Ran static checks: `cd backend && go vet ./...`, which completed without reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a814ad2f0832e90f8ae5a783f9c4b)