### PR TITLE
Prepare first release candidate v0.1.0-rc.1 — add version info, release checklist, and CI packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
           mkdir -p ../dist
-          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o ../dist/3m-ui-linux-amd64 ./cmd/server
-          CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -trimpath -ldflags "-s -w" -o ../dist/3m-ui-linux-arm64 ./cmd/server
-          CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc go build -trimpath -ldflags "-s -w" -o ../dist/3m-ui-linux-armv7 ./cmd/server
+          VERSION="${GITHUB_REF_TYPE:-}"
+          if [ "$VERSION" = "tag" ]; then VERSION="$GITHUB_REF_NAME"; else VERSION="v0.1.0-rc.1"; fi
+          GIT_COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          LDFLAGS="-s -w -X main.version=$VERSION -X main.gitCommit=$GIT_COMMIT -X main.buildTime=$BUILD_TIME"
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "$LDFLAGS" -o ../dist/3m-ui-linux-amd64 ./cmd/server
+          CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -trimpath -ldflags "$LDFLAGS" -o ../dist/3m-ui-linux-arm64 ./cmd/server
+          CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc go build -trimpath -ldflags "$LDFLAGS" -o ../dist/3m-ui-linux-armv7 ./cmd/server
 
       - name: Add deployment scripts
         run: cp scripts/install.sh scripts/update.sh scripts/uninstall.sh dist/

--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,25 @@ APP_NAME := 3m-ui
 BACKEND_DIR := backend
 FRONTEND_DIR := frontend
 DIST_DIR := dist
+VERSION ?= v0.1.0-rc.1
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildTime=$(BUILD_TIME)
 
 .PHONY: build build-linux release clean
 
 build:
+	mkdir -p $(DIST_DIR)
 	cd $(FRONTEND_DIR) && pnpm build
 	rm -rf $(BACKEND_DIR)/cmd/server/web/dist
 	cp -R $(FRONTEND_DIR)/dist $(BACKEND_DIR)/cmd/server/web/dist
-	cd $(BACKEND_DIR) && go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME) ./cmd/server
+	cd $(BACKEND_DIR) && go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME) ./cmd/server
 
 build-linux:
 	mkdir -p $(DIST_DIR)
-	cd $(BACKEND_DIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME)-linux-amd64 ./cmd/server
-	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME)-linux-arm64 ./cmd/server
-	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 go build -trimpath -ldflags "-s -w" -o ../$(DIST_DIR)/$(APP_NAME)-linux-armv7 ./cmd/server
+	cd $(BACKEND_DIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-amd64 ./cmd/server
+	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-arm64 ./cmd/server
+	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-armv7 ./cmd/server
 
 release: clean build build-linux
 	cp scripts/install.sh scripts/update.sh scripts/uninstall.sh $(DIST_DIR)/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 3m-ui
 
+**Current version:** `v0.1.0-rc.1`
+
 3m-ui is an easy-to-use VPS Web management panel built on top of the Mihomo Core, leveraging its inbound and listener capabilities. It is designed to act similarly to 3x-ui, but with a robust Mihomo backend core.
 
 ## Tech Stack
@@ -74,7 +76,7 @@
    ```
 3. Run the Go server:
    ```bash
-   go run cmd/server/main.go
+   go run ./cmd/server
    ```
    The backend API will be accessible at `http://localhost:8080/api/v1`.
 
@@ -113,7 +115,7 @@ This generates the static bundle in `frontend/dist` which can be served by any s
 
 ## Production Installation
 
-3m-ui is distributed as a single Linux server binary with the built frontend embedded into the Go executable. Official release assets include Linux binaries for `amd64`, `arm64`, and `armv7`, plus installer, updater, and uninstaller scripts.
+3m-ui is distributed as a single Linux server binary with the built frontend embedded into the Go executable. Official release assets include Linux binaries for `amd64`, `arm64`, and `armv7`, plus installer, updater, and uninstaller scripts. The first release-candidate line is `v0.1.0-rc.1`.
 
 ### Supported Platforms
 
@@ -137,6 +139,14 @@ After installation, open:
 http://SERVER_IP:8080/
 ```
 
+### Version
+
+After installation, verify the installed binary and build metadata:
+
+```bash
+3m-ui --version
+```
+
 ### Upgrade
 
 Upgrade keeps the database, user data, Mihomo configuration files, and existing application configuration. It backs up `/etc/3m-ui` before replacing the binary.
@@ -144,6 +154,8 @@ Upgrade keeps the database, user data, Mihomo configuration files, and existing 
 ```bash
 curl -fsSL https://github.com/dzx941/3m-ui/releases/latest/download/update.sh | sh
 ```
+
+To upgrade to a specific release candidate manually, download the matching binary from that GitHub Release, stop the service, replace `/usr/local/bin/3m-ui`, and start the service again. Keep `/etc/3m-ui` and `/var/lib/3m-ui` in place to preserve configuration and the SQLite database.
 
 ### Uninstall
 
@@ -199,3 +211,7 @@ make build-linux  # Build Linux release binaries
 make release      # Clean, build, cross-compile, and copy scripts
 make clean        # Remove dist/
 ```
+
+## Release Candidate Checklist
+
+See [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md) before tagging or publishing a release candidate.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,34 @@
+# 3m-ui Release Checklist
+
+Recommended first release-candidate tag: `v0.1.0-rc.1`.
+
+## Verification
+
+- [ ] Run `go fmt ./...` from `backend/` and confirm no uncommitted formatting changes remain.
+- [ ] Run `go test ./...` from `backend/`.
+- [ ] Run `go vet ./...` from `backend/`.
+- [ ] Run `pnpm build` from `frontend/`.
+- [ ] Build a release binary and verify `3m-ui --version` prints the tag, git commit, and UTC build time.
+
+## Deployment Audit
+
+- [ ] Fresh install on systemd: installer creates `/etc/3m-ui/config.yaml`, `/var/lib/3m-ui/`, installs `/usr/local/bin/3m-ui`, enables and starts `3m-ui.service`.
+- [ ] Fresh install on OpenRC: installer creates the same directories, installs `/etc/init.d/3m-ui`, adds it to the default runlevel, and starts it.
+- [ ] Upgrade on systemd and OpenRC: updater backs up `/etc/3m-ui`, replaces only `/usr/local/bin/3m-ui`, restarts the service, and keeps `/var/lib/3m-ui/3m-ui.db` intact.
+- [ ] Uninstall default mode: removes service definitions, binary, config directory, and log directory while keeping `/var/lib/3m-ui`.
+- [ ] Uninstall purge mode: `uninstall.sh --purge` removes `/var/lib/3m-ui` only after confirmation.
+
+## GitHub Actions Audit
+
+- [ ] Push a `v*` tag to trigger `.github/workflows/release.yml`.
+- [ ] Confirm frontend assets are copied from `frontend/dist` to `backend/cmd/server/web/dist` before Go builds.
+- [ ] Confirm release artifacts include `3m-ui-linux-amd64`, `3m-ui-linux-arm64`, and `3m-ui-linux-armv7`.
+- [ ] Confirm release artifacts include `install.sh`, `update.sh`, and `uninstall.sh`.
+- [ ] Download each binary artifact and run `--version` where architecture access is available.
+
+## Release Notes
+
+- [ ] Document supported Linux init systems: systemd and OpenRC.
+- [ ] Document supported architectures: amd64, arm64, armv7.
+- [ ] Document installation, upgrade, uninstall, and purge commands.
+- [ ] List remaining known issues and operational caveats.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -25,6 +25,11 @@ import (
 var frontendFiles embed.FS
 
 func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "version") {
+		fmt.Println(versionString())
+		return
+	}
+
 	configPath := defaultConfigPath()
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {

--- a/backend/cmd/server/version.go
+++ b/backend/cmd/server/version.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+var (
+	version   = "v0.1.0-rc.1"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
+func versionString() string {
+	return fmt.Sprintf("3m-ui %s\ngit commit: %s\nbuild time: %s", version, gitCommit, buildTime)
+}


### PR DESCRIPTION
### Motivation

- Prepare the project for the first release candidate and ensure reproducible build metadata is embedded in binaries. 
- Provide a release checklist and documentation so installation/upgrade/uninstall and CI release packaging can be audited easily.

### Description

- Add `--version`/`version` support and version metadata by introducing `backend/cmd/server/version.go` and printing it from `main.go` when invoked with `--version` or `version`.
- Wire LDFLAGS into local builds via `Makefile` variables (`VERSION`, `GIT_COMMIT`, `BUILD_TIME`, `LDFLAGS`) and use them when building release artifacts.
- Update the GitHub Actions release workflow to stamp binaries with version/commit/build-time LDFLAGS and continue to embed frontend assets before building artifacts.
- Update `README.md` with current version information, version verification instructions, upgrade notes, and add a new `RELEASE_CHECKLIST.md` documenting final verification and deployment audit steps.

### Testing

- Ran `go fmt ./... && go test ./... && go vet ./...` in `backend/` and all checks passed.
- Ran `pnpm build` in `frontend/` and the production build succeeded (Vite emitted a chunk-size warning but build completed).
- Performed shell syntax checks on `scripts/install.sh`, `scripts/update.sh`, and `scripts/uninstall.sh` and ran `sh -n` style checks successfully; installer/updater/uninstaller logic was reviewed and found structurally correct.
- Built a local release binary with LDFLAGS and ran `/tmp/3m-ui-version --version`, which printed the expected `v0.1.0-rc.1`, commit, and UTC build time.
- One auxiliary check failed: a small Python attempt to parse the workflow YAML using `PyYAML` failed because `PyYAML` was not installed in the environment, which is non-blocking for the release.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a8484d414832e86db9c275b257ca4)