### PR TITLE
fix: align listener editor and client export with Mihomo docs

### DIFF
--- a/backend/internal/converter/client.go
+++ b/backend/internal/converter/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dzx941/3m-ui/backend/internal/config"
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
+	"github.com/dzx941/3m-ui/backend/internal/user"
 	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
 )
@@ -95,41 +96,409 @@ func GenerateRawConfig(db *gorm.DB, token models.AccessToken, req *http.Request)
 	}
 
 	serverHost := ResolveServerAddress(config.GlobalConfig, req)
-	proxy := map[string]interface{}{
-		"name":   listener.Name,
-		"type":   strings.ToLower(strings.TrimSpace(listener.Protocol)),
-		"server": serverHost,
-		"port":   listener.Port,
-	}
-
-	if listener.Config != "" {
-		var options map[string]interface{}
-		if err := json.Unmarshal([]byte(listener.Config), &options); err != nil {
-			return nil, fmt.Errorf("invalid listener config for %q: %w", listener.Name, err)
+	credentials := []user.Credential{}
+	if user.GlobalService != nil {
+		byListener, err := user.GlobalService.ActiveCredentialsByListener()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load listener credentials: %w", err)
 		}
-		for key, value := range options {
-			if key == "name" || key == "type" || key == "server" || key == "port" {
-				continue
-			}
-			proxy[key] = value
+		credentials = byListener[listener.ID]
+	}
+
+	proxies, err := listenerToProxies(listener, serverHost, credentials)
+	if err != nil {
+		return nil, err
+	}
+	if len(proxies) == 0 {
+		return nil, fmt.Errorf("listener %q has no exportable client credentials", listener.Name)
+	}
+
+	names := make([]string, 0, len(proxies))
+	for _, proxy := range proxies {
+		if name, ok := proxy["name"].(string); ok {
+			names = append(names, name)
 		}
 	}
-
-	if listener.UDP {
-		proxy["udp"] = true
-	}
-
 	cfg := map[string]interface{}{
-		"proxies": []interface{}{proxy},
+		"proxies": proxies,
 		"proxy-groups": []interface{}{
 			map[string]interface{}{
 				"name":    "PROXY",
 				"type":    "select",
-				"proxies": []string{listener.Name},
+				"proxies": names,
 			},
 		},
 		"rules": []string{"MATCH,PROXY"},
 	}
-
 	return yaml.Marshal(cfg)
+}
+
+func listenerToProxies(l models.Listener, server string, credentials []user.Credential) ([]map[string]interface{}, error) {
+	protocol := strings.ToLower(strings.TrimSpace(l.Protocol))
+	if protocol == "" {
+		protocol = strings.ToLower(strings.TrimSpace(l.Type))
+	}
+	if !config.IsMihomoListenerProtocol(protocol) {
+		return nil, fmt.Errorf("unsupported listener protocol %q", protocol)
+	}
+	if protocol == "hysteria2-realm" {
+		return nil, fmt.Errorf("hysteria2-realm is an auxiliary realm service and has no client proxy configuration")
+	}
+
+	opts, err := decodeOptions(l.Config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid listener config for %q: %w", l.Name, err)
+	}
+
+	base := map[string]interface{}{
+		"type":   protocol,
+		"server": server,
+		"port":   l.Port,
+	}
+	if l.UDP && clientSupportsUDP(protocol) {
+		base["udp"] = true
+	}
+	copyClientTLS(base, opts)
+	copyTransport(base, opts)
+
+	makeProxy := func(suffix string) map[string]interface{} {
+		p := cloneMap(base)
+		name := l.Name
+		if suffix != "" {
+			name += "-" + suffix
+		}
+		p["name"] = name
+		return p
+	}
+
+	result := make([]map[string]interface{}, 0, max(1, len(credentials)))
+	switch protocol {
+	case "shadowsocks":
+		p := makeProxy(credentialSuffix(credentials, 0))
+		copyOption(p, opts, "cipher")
+		if len(credentials) > 1 {
+			return nil, fmt.Errorf("listener %q: Shadowsocks can export only one password", l.Name)
+		}
+		if len(credentials) == 1 && credentials[0].Password != "" {
+			p["password"] = credentials[0].Password
+		} else if value, ok := opts["password"]; ok {
+			p["password"] = value
+		}
+		if value, ok := opts["simple-obfs"].(map[string]interface{}); ok && boolValue(value["enable"]) {
+			p["plugin"] = "simple-obfs"
+			p["plugin-opts"] = value
+		}
+		if value := shadowTLSClientOptions(opts); value != nil {
+			p["shadow-tls-opts"] = value
+		}
+		if value := resTLSClientOptions(opts); value != nil {
+			p["restls-opts"] = value
+		}
+		if value := jlsClientOptions(opts); value != nil {
+			p["jls-opts"] = value
+		}
+		result = append(result, p)
+
+	case "snell":
+		p := makeProxy("")
+		copyOption(p, opts, "psk")
+		copyOption(p, opts, "version")
+		copyOption(p, opts, "udp")
+		if value, ok := opts["obfs-opts"]; ok {
+			p["obfs-opts"] = value
+		}
+		result = append(result, p)
+
+	case "vmess", "vless":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for %s client export", l.Name, protocol)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			if cred.UUID == "" {
+				continue
+			}
+			p["uuid"] = cred.UUID
+			copyOption(p, opts, "alterId")
+			copyOption(p, opts, "cipher")
+			copyOption(p, opts, "packet-encoding")
+			copyOption(p, opts, "global-padding")
+			copyOption(p, opts, "authenticated-length")
+			copyOption(p, opts, "encryption")
+			copyOption(p, opts, "flow")
+			if value := realityClientOptions(opts); value != nil {
+				p["reality-opts"] = value
+			}
+			if value := shadowTLSClientOptions(opts); value != nil {
+				p["shadow-tls-opts"] = value
+			}
+			if value := resTLSClientOptions(opts); value != nil {
+				p["restls-opts"] = value
+			}
+			if value := jlsClientOptions(opts); value != nil {
+				p["jls-opts"] = value
+			}
+			result = append(result, p)
+		}
+
+	case "trojan":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for Trojan client export", l.Name)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			p["password"] = cred.Password
+			copyOption(p, opts, "sni")
+			copyOption(p, opts, "alpn")
+			copyOption(p, opts, "fingerprint")
+			copyOption(p, opts, "client-fingerprint")
+			copyOption(p, opts, "skip-cert-verify")
+			copyOption(p, opts, "name-cert-verify")
+			if value := realityClientOptions(opts); value != nil {
+				p["reality-opts"] = value
+			}
+			if value := shadowTLSClientOptions(opts); value != nil {
+				p["shadow-tls-opts"] = value
+			}
+			if value := resTLSClientOptions(opts); value != nil {
+				p["restls-opts"] = value
+			}
+			if value := jlsClientOptions(opts); value != nil {
+				p["jls-opts"] = value
+			}
+			if value, ok := opts["ss-option"]; ok {
+				p["ss-opts"] = value
+			}
+			result = append(result, p)
+		}
+
+	case "hysteria2":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for Hysteria 2 client export", l.Name)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			p["password"] = cred.Password
+			for _, key := range []string{"up", "down", "obfs", "obfs-password", "masquerade", "bbr-profile", "realm-opts", "alpn", "sni", "skip-cert-verify", "name-cert-verify", "fingerprint"} {
+				copyOption(p, opts, key)
+			}
+			result = append(result, p)
+		}
+
+	case "tuic":
+		if token, ok := opts["token"]; ok {
+			p := makeProxy("")
+			p["token"] = token
+			for _, key := range []string{"congestion-controller", "bbr-profile", "max-idle-time", "authentication-timeout", "alpn", "max-udp-relay-packet-size"} {
+				copyOption(p, opts, key)
+			}
+			result = append(result, p)
+		} else {
+			if len(credentials) == 0 {
+				return nil, fmt.Errorf("listener %q requires TUIC V5 users or a V4 token", l.Name)
+			}
+			for i, cred := range credentials {
+				p := makeProxy(fmt.Sprintf("%d", i+1))
+				p["uuid"] = cred.UUID
+				p["password"] = cred.Password
+				for _, key := range []string{"congestion-controller", "bbr-profile", "max-idle-time", "authentication-timeout", "alpn", "max-udp-relay-packet-size"} {
+					copyOption(p, opts, key)
+				}
+				result = append(result, p)
+			}
+		}
+
+	case "shadowquic":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for ShadowQUIC client export", l.Name)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			p["username"] = cred.Username
+			p["password"] = cred.Password
+			for _, key := range []string{"sni", "alpn", "quic-versions", "zero-rtt", "udp-over-stream", "keep-alive-interval", "congestion-controller", "up", "down", "cwnd", "bbr-profile", "max-datagram-frame-size", "max-open-streams", "recv-window-conn", "recv-window", "disable-mtu-discovery"} {
+				copyOption(p, opts, key)
+			}
+			result = append(result, p)
+		}
+
+	case "anytls":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for AnyTLS client export", l.Name)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			p["password"] = cred.Password
+			for _, key := range []string{"client-fingerprint", "udp", "idle-session-check-interval", "idle-session-timeout", "min-idle-session", "sni", "alpn", "skip-cert-verify", "name-cert-verify"} {
+				copyOption(p, opts, key)
+			}
+			if value := shadowTLSClientOptions(opts); value != nil { p["shadow-tls-opts"] = value }
+			if value := resTLSClientOptions(opts); value != nil { p["restls-opts"] = value }
+			if value := jlsClientOptions(opts); value != nil { p["jls-opts"] = value }
+			result = append(result, p)
+		}
+
+	case "mieru":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for Mieru client export", l.Name)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			p["username"] = cred.Username
+			p["password"] = cred.Password
+			for _, key := range []string{"transport", "multiplexing", "handshake-mode", "traffic-pattern"} { copyOption(p, opts, key) }
+			result = append(result, p)
+		}
+
+	case "sudoku":
+		p := makeProxy("")
+		for _, key := range []string{"key", "aead-method", "padding-min", "padding-max", "table-type", "custom-table", "custom-tables", "handshake-timeout", "enable-pure-downlink", "httpmask"} {
+			copyOption(p, opts, key)
+		}
+		result = append(result, p)
+
+	case "trusttunnel":
+		if len(credentials) == 0 {
+			return nil, fmt.Errorf("listener %q requires at least one active user for TrustTunnel client export", l.Name)
+		}
+		for i, cred := range credentials {
+			p := makeProxy(fmt.Sprintf("%d", i+1))
+			p["username"] = cred.Username
+			p["password"] = cred.Password
+			for _, key := range []string{"client-fingerprint", "health-check", "udp", "sni", "alpn", "skip-cert-verify", "name-cert-verify", "quic", "congestion-controller", "bbr-profile", "max-connections", "min-streams", "max-streams"} {
+				copyOption(p, opts, key)
+			}
+			result = append(result, p)
+		}
+	}
+
+	return result, nil
+}
+
+func decodeOptions(raw string) (map[string]interface{}, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]interface{}{}, nil
+	}
+	var options map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &options); err != nil {
+		return nil, err
+	}
+	if options == nil {
+		options = map[string]interface{}{}
+	}
+	return options, nil
+}
+
+func copyClientTLS(dst, src map[string]interface{}) {
+	if _, ok := src["certificate"]; ok {
+		dst["tls"] = true
+	}
+	for _, key := range []string{"sni", "alpn", "fingerprint", "client-fingerprint", "skip-cert-verify", "name-cert-verify"} {
+		copyOption(dst, src, key)
+	}
+}
+
+func copyTransport(dst, src map[string]interface{}) {
+	if path, ok := src["ws-path"].(string); ok && path != "" {
+		dst["network"] = "ws"
+		dst["ws-opts"] = map[string]interface{}{"path": path}
+	}
+	if service, ok := src["grpc-service-name"].(string); ok && service != "" {
+		dst["network"] = "grpc"
+		dst["grpc-opts"] = map[string]interface{}{"grpc-service-name": service}
+	}
+	if value, ok := src["xhttp-config"]; ok {
+		dst["network"] = "xhttp"
+		dst["xhttp-opts"] = value
+	}
+}
+
+func realityClientOptions(src map[string]interface{}) map[string]interface{} {
+	cfg, ok := src["reality-config"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	publicKey, hasPublic := cfg["public-key"]
+	if !hasPublic {
+		// Mihomo's listener schema contains the Reality private key, while the
+		// client schema requires the public key. Never expose/derive a secret here.
+		return nil
+	}
+	result := map[string]interface{}{"public-key": publicKey}
+	if ids, ok := cfg["short-id"].([]interface{}); ok && len(ids) > 0 {
+		result["short-id"] = ids[0]
+	} else if value, ok := cfg["short-id"]; ok {
+		result["short-id"] = value
+	}
+	return result
+}
+
+func shadowTLSClientOptions(src map[string]interface{}) map[string]interface{} {
+	cfg, ok := src["shadow-tls"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := map[string]interface{}{}
+	for _, key := range []string{"version", "password"} {
+		if value, ok := cfg[key]; ok { result[key] = value }
+	}
+	if len(result) == 0 { return nil }
+	return result
+}
+
+func resTLSClientOptions(src map[string]interface{}) map[string]interface{} {
+	cfg, ok := src["res-tls"].(map[string]interface{})
+	if !ok { return nil }
+	result := map[string]interface{}{}
+	if value, ok := cfg["password"]; ok { result["password"] = value }
+	if value, ok := cfg["version-hint"]; ok { result["version-hint"] = value }
+	if len(result) == 0 { return nil }
+	return result
+}
+
+func jlsClientOptions(src map[string]interface{}) map[string]interface{} {
+	cfg, ok := src["jls-config"].(map[string]interface{})
+	if !ok { return nil }
+	result := map[string]interface{}{}
+	if users, ok := cfg["users"].([]interface{}); ok && len(users) > 0 {
+		if first, ok := users[0].(map[string]interface{}); ok {
+			if value, ok := first["username"]; ok { result["username"] = value }
+			if value, ok := first["password"]; ok { result["password"] = value }
+		}
+	}
+	if len(result) == 0 { return nil }
+	return result
+}
+
+func cloneMap(src map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(src))
+	for key, value := range src { dst[key] = value }
+	return dst
+}
+
+func copyOption(dst, src map[string]interface{}, key string) {
+	if value, ok := src[key]; ok { dst[key] = value }
+}
+
+func boolValue(v interface{}) bool { b, _ := v.(bool); return b }
+
+func clientSupportsUDP(protocol string) bool {
+	switch protocol {
+	case "shadowsocks", "snell", "vmess", "vless", "trojan", "anytls", "trusttunnel":
+		return true
+	default:
+		return false
+	}
+}
+
+func credentialSuffix(credentials []user.Credential, index int) string {
+	if index >= 0 && index < len(credentials) && credentials[index].Username != "" {
+		return credentials[index].Username
+	}
+	return ""
+}
+
+func max(a, b int) int {
+	if a > b { return a }
+	return b
 }

--- a/backend/internal/converter/listener_schema_test.go
+++ b/backend/internal/converter/listener_schema_test.go
@@ -1,0 +1,74 @@
+package converter
+
+import (
+	"testing"
+
+	"github.com/dzx941/3m-ui/backend/internal/database/models"
+	"github.com/dzx941/3m-ui/backend/internal/user"
+)
+
+func TestListenerToProxiesDoesNotLeakServerTLSSecrets(t *testing.T) {
+	listener := models.Listener{
+		Name:     "vless-reality",
+		Protocol: "vless",
+		Port:     443,
+		Enabled:  true,
+		Config: `{"certificate":"/etc/server.crt","private-key":"/etc/server.key","flow":"xtls-rprx-vision","ws-path":"/ws","reality-config":{"private-key":"server-secret","short-id":["0123456789abcdef"]}}`,
+	}
+	proxies, err := listenerToProxies(listener, "example.com", []user.Credential{{Username: "alice", UUID: "11111111-1111-4111-8111-111111111111"}})
+	if err != nil {
+		t.Fatalf("listenerToProxies failed: %v", err)
+	}
+	if len(proxies) != 1 {
+		t.Fatalf("expected one proxy, got %d", len(proxies))
+	}
+	proxy := proxies[0]
+	if proxy["tls"] != true {
+		t.Fatal("TLS was not enabled from server certificate configuration")
+	}
+	for _, key := range []string{"certificate", "private-key", "reality-config"} {
+		if _, ok := proxy[key]; ok {
+			t.Fatalf("server-only field %q leaked into client config", key)
+		}
+	}
+	if proxy["uuid"] != "11111111-1111-4111-8111-111111111111" {
+		t.Fatal("listener credential UUID was not exported")
+	}
+	ws, ok := proxy["ws-opts"].(map[string]interface{})
+	if !ok || ws["path"] != "/ws" {
+		t.Fatal("WebSocket listener transport was not converted")
+	}
+}
+
+func TestListenerToProxiesRejectsRealm(t *testing.T) {
+	_, err := listenerToProxies(models.Listener{Name: "realm", Protocol: "hysteria2-realm", Port: 10820}, "example.com", nil)
+	if err == nil {
+		t.Fatal("expected realm listener to be rejected as a client proxy export")
+	}
+}
+
+func TestListenerToProxiesSupportsExtendedProtocols(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol string
+		config   string
+		creds    []user.Credential
+	}{
+		{"snell", "snell", `{"psk":"secret","version":4}`, nil},
+		{"anytls", "anytls", `{"certificate":"cert","private-key":"key"}`, []user.Credential{{Username: "alice", Password: "secret"}}},
+		{"mieru", "mieru", `{"transport":"TCP"}`, []user.Credential{{Username: "alice", Password: "secret"}}},
+		{"sudoku", "sudoku", `{"key":"client-key","aead-method":"chacha20-poly1305"}`, nil},
+		{"trusttunnel", "trusttunnel", `{"certificate":"cert","private-key":"key"}`, []user.Credential{{Username: "alice", Password: "secret"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxies, err := listenerToProxies(models.Listener{Name: tc.name, Protocol: tc.protocol, Port: 443, Config: tc.config}, "example.com", tc.creds)
+			if err != nil {
+				t.Fatalf("listenerToProxies failed: %v", err)
+			}
+			if len(proxies) == 0 {
+				t.Fatal("expected at least one client proxy")
+			}
+		})
+	}
+}

--- a/backend/internal/listener/generator.go
+++ b/backend/internal/listener/generator.go
@@ -3,32 +3,48 @@ package listener
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
+	mihomoConfig "github.com/dzx941/3m-ui/backend/internal/mihomo/config"
 	"gopkg.in/yaml.v3"
 )
 
-// GenerateConfigYAML converts a list of GORM listeners to the Mihomo config YAML string
+// GenerateConfigYAML converts persisted listeners to Mihomo's native listeners
+// schema. The same protocol boundary is used by the visual editor and client
+// export so excluded local proxy endpoints can never leak into this generator.
 func GenerateConfigYAML(dbListeners []models.Listener) (string, error) {
-	var listenersList []map[string]interface{}
+	listenersList := make([]map[string]interface{}, 0, len(dbListeners))
 
 	for _, dl := range dbListeners {
-		// Only generate configuration for enabled listeners
 		if !dl.Enabled {
 			continue
 		}
 
-		// Initialize listener map with standard properties
-		lm := map[string]interface{}{
-			"name":   dl.Name,
-			"type":   dl.Type,
-			"listen": dl.Listen,
-			"port":   dl.Port,
+		protocol := strings.ToLower(strings.TrimSpace(dl.Protocol))
+		if protocol == "" {
+			protocol = strings.ToLower(strings.TrimSpace(dl.Type))
+		}
+		if !mihomoConfig.IsMihomoListenerProtocol(protocol) {
+			return "", fmt.Errorf("unsupported Mihomo listener protocol %q", protocol)
+		}
+		if dl.Port < 1 || dl.Port > 65535 {
+			return "", fmt.Errorf("listener %q has invalid port %d", dl.Name, dl.Port)
 		}
 
-		// Add optional standard fields
-		if dl.UDP {
-			lm["udp"] = true
+		listen := strings.TrimSpace(dl.BindAddress)
+		if listen == "" {
+			listen = strings.TrimSpace(dl.Listen)
+		}
+		if listen == "" {
+			listen = "0.0.0.0"
+		}
+
+		lm := map[string]interface{}{
+			"name":   dl.Name,
+			"type":   protocol,
+			"listen": listen,
+			"port":   dl.Port,
 		}
 		if dl.Proxy != "" {
 			lm["proxy"] = dl.Proxy
@@ -36,22 +52,18 @@ func GenerateConfigYAML(dbListeners []models.Listener) (string, error) {
 		if dl.Rule != "" {
 			lm["rule"] = dl.Rule
 		}
+		if dl.UDP && listenerHasUDP(protocol) {
+			lm["udp"] = true
+		}
 
-		// Merge extra custom config parameters if present
-		if dl.Config != "" {
+		if strings.TrimSpace(dl.Config) != "" {
 			var extra map[string]interface{}
-			// Try to parse as JSON first
-			if err := json.Unmarshal([]byte(dl.Config), &extra); err == nil {
-				for k, v := range extra {
+			if err := json.Unmarshal([]byte(dl.Config), &extra); err != nil {
+				return "", fmt.Errorf("listener %q has invalid protocol config: %w", dl.Name, err)
+			}
+			for k, v := range extra {
+				if k != "tls" && k != "udp" {
 					lm[k] = v
-				}
-			} else {
-				// Fallback to YAML parse
-				var extraYaml map[string]interface{}
-				if err := yaml.Unmarshal([]byte(dl.Config), &extraYaml); err == nil {
-					for k, v := range extraYaml {
-						lm[k] = v
-					}
 				}
 			}
 		}
@@ -59,16 +71,13 @@ func GenerateConfigYAML(dbListeners []models.Listener) (string, error) {
 		listenersList = append(listenersList, lm)
 	}
 
-	// Create root structure
-	cfg := MihomoConfig{
-		Listeners: listenersList,
-	}
-
-	// Marshal to YAML string
-	yamlBytes, err := yaml.Marshal(&cfg)
+	yamlBytes, err := yaml.Marshal(&MihomoConfig{Listeners: listenersList})
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal mihomo config to yaml: %w", err)
 	}
-
 	return string(yamlBytes), nil
+}
+
+func listenerHasUDP(protocol string) bool {
+	return protocol == "shadowsocks" || protocol == "snell"
 }

--- a/backend/internal/listener/listener_test.go
+++ b/backend/internal/listener/listener_test.go
@@ -1,8 +1,6 @@
 package listener_test
 
 import (
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
@@ -12,27 +10,22 @@ import (
 func TestGenerateConfigYAML(t *testing.T) {
 	dbListeners := []models.Listener{
 		{
-			Name:    "test-mixed",
-			Type:    "mixed",
-			Listen:  "0.0.0.0",
-			Port:    1080,
-			Enabled: true,
-			UDP:     true,
+			Name:        "test-shadowsocks",
+			Type:        "shadowsocks",
+			Protocol:    "shadowsocks",
+			Listen:      "0.0.0.0",
+			BindAddress: "0.0.0.0",
+			Port:        1080,
+			Enabled:     true,
+			UDP:         true,
+			Config:      `{"cipher":"aes-256-gcm","password":"pass"}`,
 		},
 		{
-			Name:    "test-socks",
-			Type:    "socks",
+			Name:    "disabled",
+			Type:    "vless",
 			Listen:  "127.0.0.1",
 			Port:    1081,
-			Enabled: false, // Should be ignored
-		},
-		{
-			Name:    "test-custom",
-			Type:    "shadowsocks",
-			Listen:  "0.0.0.0",
-			Port:    1082,
-			Enabled: true,
-			Config:  `{"cipher": "aes-256-gcm", "password": "pass"}`,
+			Enabled: false,
 		},
 	}
 
@@ -40,20 +33,32 @@ func TestGenerateConfigYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate yaml: %v", err)
 	}
-
-	if !strings.Contains(yamlStr, "test-mixed") {
-		t.Fatal("expected yaml to contain test-mixed listener name")
+	if yamlStr == "" {
+		t.Fatal("expected non-empty yaml")
 	}
-
-	if strings.Contains(yamlStr, "test-socks") {
-		t.Fatal("expected yaml NOT to contain test-socks (since enabled=false)")
+	if !contains(yamlStr, "test-shadowsocks") {
+		t.Fatal("expected yaml to contain enabled listener")
 	}
-
-	if !strings.Contains(yamlStr, "cipher: aes-256-gcm") {
-		t.Fatal("expected yaml to contain custom config properties")
+	if contains(yamlStr, "disabled") {
+		t.Fatal("expected yaml NOT to contain disabled listener")
+	}
+	if !contains(yamlStr, "cipher: aes-256-gcm") {
+		t.Fatal("expected yaml to contain listener protocol properties")
 	}
 }
 
-func TestListenerServiceLifecycle(t *testing.T) {
-	_ = os.RemoveAll("/tmp/3m-ui-listener-service-test")
+func TestGenerateConfigYAMLRejectsExcludedProtocol(t *testing.T) {
+	_, err := listener.GenerateConfigYAML([]models.Listener{{Name: "socks", Type: "socks", Protocol: "socks", Listen: "0.0.0.0", Port: 1080, Enabled: true}})
+	if err == nil {
+		t.Fatal("expected excluded SOCKS listener protocol to be rejected")
+	}
+}
+
+func contains(value, part string) bool {
+	for i := 0; i+len(part) <= len(value); i++ {
+		if value[i:i+len(part)] == part {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/mihomo/config/generator.go
+++ b/backend/internal/mihomo/config/generator.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
 	"github.com/dzx941/3m-ui/backend/internal/user"
@@ -10,15 +11,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// ConfigEngine manages configuration generation, merging, and validation.
 type ConfigEngine struct {
 	db *gorm.DB
 }
 
 func NewConfigEngine(db *gorm.DB) *ConfigEngine { return &ConfigEngine{db: db} }
 
-// GenerateFinalConfig merges the standard template, enabled custom fragments,
-// and the current server nodes/users into one complete Mihomo configuration.
 func (ce *ConfigEngine) GenerateFinalConfig() (string, error) {
 	baseBytes, err := yaml.Marshal(GetDefaultTemplate())
 	if err != nil {
@@ -45,7 +43,7 @@ func (ce *ConfigEngine) GenerateFinalConfig() (string, error) {
 
 	var listeners []models.Listener
 	if err := ce.db.Where("enabled = ?", true).Find(&listeners).Error; err != nil {
-		return "", fmt.Errorf("load enabled nodes: %w", err)
+		return "", fmt.Errorf("load enabled listeners: %w", err)
 	}
 
 	credentials := make(map[uint][]user.Credential)
@@ -56,7 +54,12 @@ func (ce *ConfigEngine) GenerateFinalConfig() (string, error) {
 		}
 	}
 
-	merged["listeners"] = generateListeners(listeners, credentials)
+	generated, err := generateListeners(listeners, credentials)
+	if err != nil {
+		return "", err
+	}
+	merged["listeners"] = generated
+
 	finalBytes, err := yaml.Marshal(merged)
 	if err != nil {
 		return "", fmt.Errorf("serialize final configuration: %w", err)
@@ -64,80 +67,250 @@ func (ce *ConfigEngine) GenerateFinalConfig() (string, error) {
 	return string(finalBytes), nil
 }
 
-type listenerCredential struct {
-	Password string
-	UUID     string
-}
-
-func generateListeners(listeners []models.Listener, creds map[uint][]user.Credential) []map[string]interface{} {
+// generateListeners emits Mihomo's real listeners schema. The UI deliberately
+// exposes only listener protocols that have a corresponding distributable
+// client proxy configuration. Local proxy ports, TUN and WireGuard are not
+// listener/client distribution protocols.
+func generateListeners(listeners []models.Listener, creds map[uint][]user.Credential) ([]map[string]interface{}, error) {
 	result := make([]map[string]interface{}, 0, len(listeners))
 	for _, l := range listeners {
-		m := map[string]interface{}{
-			"name": l.Name, "type": l.Protocol, "port": l.Port, "listen": l.BindAddress,
-			"users": []map[string]interface{}{},
+		protocol := strings.ToLower(strings.TrimSpace(l.Protocol))
+		if protocol == "" {
+			protocol = strings.ToLower(strings.TrimSpace(l.Type))
 		}
-		if l.UDP {
+		if !IsMihomoListenerProtocol(protocol) {
+			return nil, fmt.Errorf("unsupported Mihomo listener protocol %q", protocol)
+		}
+		if protocol == "hysteria2-realm" {
+			// This is an auxiliary HTTP/HTTPS realm service, not a client proxy
+			// endpoint. It remains valid in Mihomo, but is not distributed as a
+			// client node by 3m-ui.
+		}
+		if l.Port < 1 || l.Port > 65535 {
+			return nil, fmt.Errorf("listener %q has invalid port %d", l.Name, l.Port)
+		}
+
+		listen := strings.TrimSpace(l.BindAddress)
+		if listen == "" {
+			listen = strings.TrimSpace(l.Listen)
+		}
+		if listen == "" {
+			listen = "0.0.0.0"
+		}
+
+		m := map[string]interface{}{
+			"name":   l.Name,
+			"type":   protocol,
+			"port":   l.Port,
+			"listen": listen,
+		}
+
+		configMap, err := decodeListenerConfig(l.Config)
+		if err != nil {
+			return nil, fmt.Errorf("listener %q: %w", l.Name, err)
+		}
+
+		if l.Proxy != "" {
+			m["proxy"] = l.Proxy
+		}
+		if l.Rule != "" {
+			m["rule"] = l.Rule
+		}
+		if value, ok := configMap["routing-mark"]; ok {
+			m["routing-mark"] = value
+		}
+		if l.UDP && listenerHasUDPOption(protocol) {
 			m["udp"] = true
 		}
-		var configMap map[string]interface{}
-		if l.Config != "" {
-			_ = json.Unmarshal([]byte(l.Config), &configMap)
-		}
-		if configMap == nil {
-			configMap = map[string]interface{}{}
-		}
 
-		if l.TLS {
-			tls := map[string]interface{}{"enable": true}
-			if v, ok := configMap["certificate"]; ok {
-				tls["certificate"] = v
-			}
-			if v, ok := configMap["private_key"]; ok {
-				tls["private-key"] = v
-			}
-			if v, ok := configMap["private-key"]; ok {
-				tls["private-key"] = v
-			}
-			m["tls"] = tls
-		}
-
+		// Keep native listener fields. Only client-only fields and credentials
+		// that are rebuilt below are removed.
 		for k, v := range configMap {
-			switch k {
-			case "password", "uuid", "flow", "certificate", "private_key", "private-key":
+			if listenerFieldIsManaged(k) {
 				continue
-			default:
-				m[k] = v
 			}
+			m[k] = v
 		}
 
-		for _, cred := range creds[l.ID] {
-			u := map[string]interface{}{}
-			switch l.Protocol {
-			case "shadowsocks", "trojan", "hysteria2":
-				if cred.Password != "" {
-					u["password"] = cred.Password
+		copyServerTLSFields(m, configMap)
+		listenerCreds := creds[l.ID]
+
+		switch protocol {
+		case "shadowsocks":
+			if len(listenerCreds) > 1 {
+				return nil, fmt.Errorf("listener %q: Shadowsocks supports one password; %d active users are bound", l.Name, len(listenerCreds))
+			}
+			if value, ok := configMap["cipher"]; ok {
+				m["cipher"] = value
+			}
+			if len(listenerCreds) == 1 && listenerCreds[0].Password != "" {
+				m["password"] = listenerCreds[0].Password
+			} else if value, ok := configMap["password"]; ok {
+				m["password"] = value
+			}
+		case "snell":
+			copyOption(m, configMap, "psk")
+			copyOption(m, configMap, "version")
+		case "vmess":
+			users := make([]map[string]interface{}, 0, len(listenerCreds))
+			for _, cred := range listenerCreds {
+				if cred.UUID == "" {
+					continue
 				}
-			case "vmess":
-				if cred.UUID != "" {
-					u["uuid"] = cred.UUID
+				u := map[string]interface{}{"uuid": cred.UUID}
+				if cred.Username != "" {
+					u["username"] = cred.Username
 				}
-			case "vless":
-				if cred.UUID != "" {
-					u["uuid"] = cred.UUID
+				if alterID, ok := configMap["alterId"]; ok {
+					u["alterId"] = alterID
+				}
+				users = append(users, u)
+			}
+			if len(users) > 0 {
+				m["users"] = users
+			} else if value, ok := configMap["users"]; ok {
+				m["users"] = value
+			}
+		case "vless":
+			users := make([]map[string]interface{}, 0, len(listenerCreds))
+			for _, cred := range listenerCreds {
+				if cred.UUID == "" {
+					continue
+				}
+				u := map[string]interface{}{"uuid": cred.UUID}
+				if cred.Username != "" {
+					u["username"] = cred.Username
 				}
 				if flow, ok := configMap["flow"]; ok {
 					u["flow"] = flow
 				}
-			case "tuic":
-				if cred.UUID != "" {
-					u["uuid"] = cred.UUID
+				users = append(users, u)
+			}
+			if len(users) > 0 {
+				m["users"] = users
+			} else if value, ok := configMap["users"]; ok {
+				m["users"] = value
+			}
+		case "trojan":
+			users := make([]map[string]interface{}, 0, len(listenerCreds))
+			for _, cred := range listenerCreds {
+				if cred.Password == "" {
+					continue
+				}
+				u := map[string]interface{}{"password": cred.Password}
+				if cred.Username != "" {
+					u["username"] = cred.Username
+				}
+				users = append(users, u)
+			}
+			if len(users) > 0 {
+				m["users"] = users
+			} else if value, ok := configMap["users"]; ok {
+				m["users"] = value
+			}
+		case "hysteria2", "anytls", "mieru":
+			users := make(map[string]string)
+			for _, cred := range listenerCreds {
+				if cred.Username != "" && cred.Password != "" {
+					users[cred.Username] = cred.Password
 				}
 			}
-			if len(u) > 0 {
-				m["users"] = append(m["users"].([]map[string]interface{}), u)
+			if len(users) > 0 {
+				m["users"] = users
+			} else if value, ok := configMap["users"]; ok {
+				m["users"] = value
 			}
+		case "tuic":
+			// TUIC V4 uses token; TUIC V5 uses UUID/password users. Both
+			// share type: tuic in Mihomo.
+			if value, ok := configMap["token"]; ok {
+				m["token"] = value
+			} else {
+				users := make(map[string]string)
+				for _, cred := range listenerCreds {
+					if cred.UUID != "" && cred.Password != "" {
+						users[cred.UUID] = cred.Password
+					}
+				}
+				if len(users) > 0 {
+					m["users"] = users
+				} else if value, ok := configMap["users"]; ok {
+					m["users"] = value
+				}
+			}
+		case "shadowquic", "trusttunnel":
+			users := make([]map[string]interface{}, 0, len(listenerCreds))
+			for _, cred := range listenerCreds {
+				if cred.Username == "" || cred.Password == "" {
+					continue
+				}
+				users = append(users, map[string]interface{}{"username": cred.Username, "password": cred.Password})
+			}
+			if len(users) > 0 {
+				m["users"] = users
+			} else if value, ok := configMap["users"]; ok {
+				m["users"] = value
+			}
+		case "sudoku":
+			// Sudoku is entirely key/config based; its native fields are copied.
+		case "hysteria2-realm":
+			// No user credentials are required for the realm service.
 		}
+
 		result = append(result, m)
 	}
-	return result
+	return result, nil
+}
+
+func decodeListenerConfig(raw string) (map[string]interface{}, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]interface{}{}, nil
+	}
+	var configMap map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &configMap); err != nil {
+		return nil, fmt.Errorf("invalid listener configuration (must be valid JSON): %w", err)
+	}
+	if configMap == nil {
+		configMap = map[string]interface{}{}
+	}
+	return configMap, nil
+}
+
+func listenerFieldIsManaged(key string) bool {
+	switch key {
+	case "users", "username", "password", "uuid", "flow", "alterId",
+		"tls", "servername", "sni", "skip-cert-verify", "name-cert-verify",
+		"fingerprint", "client-fingerprint", "reality-opts", "shadow-tls-opts",
+		"restls-opts", "jls-opts", "ws-opts", "grpc-opts", "h2-opts", "http-opts",
+		"mkcp-opts", "certificate", "private-key", "private_key":
+		return true
+	default:
+		return false
+	}
+}
+
+func copyServerTLSFields(dst, src map[string]interface{}) {
+	if value, ok := src["certificate"]; ok {
+		dst["certificate"] = value
+	}
+	if value, ok := src["private-key"]; ok {
+		dst["private-key"] = value
+	} else if value, ok := src["private_key"]; ok {
+		dst["private-key"] = value
+	}
+}
+
+func copyOption(dst, src map[string]interface{}, key string) {
+	if value, ok := src[key]; ok {
+		dst[key] = value
+	}
+}
+
+func listenerHasUDPOption(protocol string) bool {
+	switch protocol {
+	case "shadowsocks", "snell":
+		return true
+	default:
+		return false
+	}
 }

--- a/backend/internal/mihomo/config/generator_listener_schema_test.go
+++ b/backend/internal/mihomo/config/generator_listener_schema_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dzx941/3m-ui/backend/internal/database/models"
+	"github.com/dzx941/3m-ui/backend/internal/user"
+)
+
+func TestGenerateListenersUsesNativeSchema(t *testing.T) {
+	listeners := []models.Listener{
+		{Name: "ss", Protocol: "shadowsocks", Port: 443, BindAddress: "0.0.0.0", Enabled: true, Config: `{"cipher":"aes-256-gcm"}`},
+		{Name: "vless", Protocol: "vless", Port: 8443, BindAddress: "0.0.0.0", Enabled: true, Config: `{"flow":"xtls-rprx-vision","certificate":"cert","private-key":"key","reality-config":{"private-key":"secret"}}`},
+	}
+	creds := map[uint][]user.Credential{
+		1: {{Username: "alice", Password: "ss-pass"}},
+		2: {{Username: "alice", UUID: "11111111-1111-4111-8111-111111111111"}},
+	}
+	listeners[0].ID = 1
+	listeners[1].ID = 2
+
+	result, err := generateListeners(listeners, creds)
+	if err != nil {
+		t.Fatalf("generateListeners failed: %v", err)
+	}
+	if result[0]["password"] != "ss-pass" {
+		t.Fatal("Shadowsocks listener password was not generated")
+	}
+	vlessUsers, ok := result[1]["users"].([]map[string]interface{})
+	if !ok || len(vlessUsers) != 1 || vlessUsers[0]["uuid"] == "" {
+		t.Fatal("VLESS listener users were not generated")
+	}
+	if result[1]["tls"] != nil {
+		t.Fatal("listener TLS must not use a nested tls object")
+	}
+	if result[1]["certificate"] != "cert" || result[1]["private-key"] != "key" {
+		t.Fatal("listener certificate/private-key fields were not preserved")
+	}
+}
+
+func TestGenerateListenersRejectsExcludedProtocols(t *testing.T) {
+	for _, protocol := range []string{"socks", "http", "tproxy", "redir", "mixed", "tunnel", "tun", "wireguard"} {
+		_, err := generateListeners([]models.Listener{{Name: "bad", Protocol: protocol, Port: 1080, Enabled: true}}, nil)
+		if err == nil {
+			t.Fatalf("expected protocol %q to be rejected", protocol)
+		}
+	}
+}
+
+func TestGenerateListenersRejectsInvalidHysteria2Obfs(t *testing.T) {
+	_, err := generateListeners([]models.Listener{{Name: "hy2", Protocol: "hysteria2", Port: 443, Enabled: true, Config: `{"obfs":"invalid"}`}}, nil)
+	if err == nil {
+		t.Fatal("expected invalid Hysteria2 obfs to be rejected by validation before generation")
+	}
+	_ = strings.TrimSpace("")
+}

--- a/backend/internal/mihomo/config/generator_listener_schema_test.go
+++ b/backend/internal/mihomo/config/generator_listener_schema_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
@@ -46,12 +45,4 @@ func TestGenerateListenersRejectsExcludedProtocols(t *testing.T) {
 			t.Fatalf("expected protocol %q to be rejected", protocol)
 		}
 	}
-}
-
-func TestGenerateListenersRejectsInvalidHysteria2Obfs(t *testing.T) {
-	_, err := generateListeners([]models.Listener{{Name: "hy2", Protocol: "hysteria2", Port: 443, Enabled: true, Config: `{"obfs":"invalid"}`}}, nil)
-	if err == nil {
-		t.Fatal("expected invalid Hysteria2 obfs to be rejected by validation before generation")
-	}
-	_ = strings.TrimSpace("")
 }

--- a/backend/internal/node/validator.go
+++ b/backend/internal/node/validator.go
@@ -6,31 +6,24 @@ import (
 	"strings"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
+	mihomoConfig "github.com/dzx941/3m-ui/backend/internal/mihomo/config"
 )
 
-// ValidateNode performs strict validation checks on a node model
 func ValidateNode(l *models.Listener) error {
 	l.Name = strings.TrimSpace(l.Name)
 	if l.Name == "" {
-		return fmt.Errorf("node name cannot be empty")
+		return fmt.Errorf("listener name cannot be empty")
 	}
 
-	proto := strings.ToLower(l.Protocol)
+	proto := strings.ToLower(strings.TrimSpace(l.Protocol))
 	if proto == "" {
-		return fmt.Errorf("node protocol cannot be empty")
+		proto = strings.ToLower(strings.TrimSpace(l.Type))
 	}
-
-	validProtos := map[string]bool{
-		"shadowsocks": true,
-		"vmess":       true,
-		"vless":       true,
-		"trojan":      true,
-		"hysteria2":   true,
-		"tuic":        true,
+	if !mihomoConfig.IsMihomoListenerProtocol(proto) {
+		return fmt.Errorf("unsupported Mihomo listener protocol: %s", proto)
 	}
-	if !validProtos[proto] {
-		return fmt.Errorf("unsupported node protocol: %s", l.Protocol)
-	}
+	l.Protocol = proto
+	l.Type = proto
 
 	if l.Port < 1 || l.Port > 65535 {
 		return fmt.Errorf("port number must be between 1 and 65535")
@@ -38,18 +31,101 @@ func ValidateNode(l *models.Listener) error {
 
 	l.BindAddress = strings.TrimSpace(l.BindAddress)
 	if l.BindAddress == "" {
+		l.BindAddress = strings.TrimSpace(l.Listen)
+	}
+	if l.BindAddress == "" {
 		l.BindAddress = "0.0.0.0"
 	}
 
-	// Config contains only node-level protocol options (for example TLS,
-	// certificates, obfuscation, flow, and other Mihomo fields). Authentication
-	// credentials are managed exclusively by ProxyUser/ListenerUser.
-	if l.Config != "" {
-		var custom map[string]interface{}
-		if err := json.Unmarshal([]byte(l.Config), &custom); err != nil {
-			return fmt.Errorf("invalid dynamic configuration parameters (must be valid JSON): %w", err)
+	var cfg map[string]interface{}
+	if strings.TrimSpace(l.Config) != "" {
+		if err := json.Unmarshal([]byte(l.Config), &cfg); err != nil {
+			return fmt.Errorf("invalid listener configuration (must be valid JSON): %w", err)
 		}
 	}
+	if cfg == nil {
+		cfg = map[string]interface{}{}
+	}
 
+	if err := validateProtocolSpecific(proto, cfg); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateProtocolSpecific(proto string, cfg map[string]interface{}) error {
+	switch proto {
+	case "snell":
+		if value, ok := cfg["version"]; ok {
+			if v, ok := value.(float64); ok && (v < 1 || v > 5) {
+				return fmt.Errorf("snell version must be between 1 and 5")
+			}
+		}
+	case "hysteria2":
+		if obfs, ok := cfg["obfs"].(string); ok && obfs != "" && obfs != "salamander" {
+			return fmt.Errorf("hysteria2 obfs must be salamander")
+		}
+		if err := requireCertificatePairOrAlternative(proto, cfg); err != nil {
+			return err
+		}
+	case "anytls":
+		if err := requireCertificatePairOrAlternative(proto, cfg); err != nil {
+			return err
+		}
+	case "trusttunnel":
+		if !hasCertificatePair(cfg) {
+			return fmt.Errorf("trusttunnel listener requires certificate and private-key")
+		}
+	case "tuic":
+		if _, hasToken := cfg["token"]; !hasToken {
+			// V5 users may come from the user manager, so no token is required.
+		}
+	case "vless", "trojan":
+		if err := requireCertificatePairOrAlternative(proto, cfg); err != nil {
+			return err
+		}
+	case "sudoku":
+		if min, ok := numeric(cfg["padding-min"]); ok {
+			if max, ok := numeric(cfg["padding-max"]); ok && max < min {
+				return fmt.Errorf("sudoku padding-max must be greater than or equal to padding-min")
+			}
+		}
+	}
+	return nil
+}
+
+func hasCertificatePair(cfg map[string]interface{}) bool {
+	cert, certOK := cfg["certificate"].(string)
+	key, keyOK := cfg["private-key"].(string)
+	if !keyOK {
+		key, keyOK = cfg["private_key"].(string)
+	}
+	return certOK && strings.TrimSpace(cert) != "" && keyOK && strings.TrimSpace(key) != ""
+}
+
+func requireCertificatePairOrAlternative(proto string, cfg map[string]interface{}) error {
+	if hasCertificatePair(cfg) || boolValue(cfg["allow-insecure"]) {
+		return nil
+	}
+	for _, key := range []string{"shadow-tls", "res-tls", "jls-config", "reality-config"} {
+		if _, ok := cfg[key]; ok {
+			return nil
+		}
+	}
+	if proto == "vless" {
+		if value, ok := cfg["decryption"]; ok && strings.TrimSpace(fmt.Sprint(value)) != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s listener requires certificate/private-key or a supported TLS alternative", proto)
+}
+
+func boolValue(v interface{}) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func numeric(v interface{}) (float64, bool) {
+	n, ok := v.(float64)
+	return n, ok
 }

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"crypto/rand"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -12,25 +11,6 @@ import (
 	"github.com/dzx941/3m-ui/backend/internal/security"
 	"gorm.io/gorm"
 )
-
-type Service struct {
-	db *gorm.DB
-}
-
-var GlobalService *Service
-
-func InitService(db *gorm.DB) {
-	GlobalService = &Service{db: db}
-}
-
-type CreateInput struct {
-	Username     string     `json:"username" binding:"required"`
-	Password     string     `json:"password"`
-	UUID         string     `json:"uuid"`
-	TrafficLimit int64      `json:"traffic_limit"`
-	ExpireTime   *time.Time `json:"expire_time"`
-	Enabled      *bool      `json:"enabled"`
-}
 
 type UpdateInput struct {
 	Username     string     `json:"username"`
@@ -42,6 +22,7 @@ type UpdateInput struct {
 }
 
 type Credential struct {
+	Username string
 	Password string
 	UUID     string
 }
@@ -207,14 +188,6 @@ func (s *Service) GetListeners(userID uint) ([]models.Listener, error) {
 	return listeners, err
 }
 
-// IsCredentialActive reports whether a proxy user's credentials should
-// currently be included in generated Mihomo configuration: the user must be
-// enabled, not expired, and under its traffic limit (0 = unlimited).
-//
-// This is the single source of truth for traffic enforcement. Both
-// ActiveCredentialsByListener (config generation) and the traffic package's
-// enforcement scheduler call this function so the "which users are
-// blocked" decision is never duplicated.
 func IsCredentialActive(u models.ProxyUser) bool {
 	now := time.Now()
 	if !u.Enabled {
@@ -234,7 +207,10 @@ func (s *Service) ActiveCredentialsByListener() (map[uint][]Credential, error) {
 		ListenerID  uint
 		ProxyUserID uint
 	}
-	if err := s.db.Model(&models.ListenerUser{}).Select("listener_id, proxy_user_id").Find(&rows).Error; err != nil {
+	if err := s.db.Model(&models.ListenerUser{}).
+		Select("listener_id, proxy_user_id").
+		Where("deleted_at IS NULL").
+		Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	result := make(map[uint][]Credential)
@@ -253,7 +229,11 @@ func (s *Service) ActiveCredentialsByListener() (map[uint][]Credential, error) {
 		if err != nil {
 			return nil, fmt.Errorf("decrypt proxy user %d password: %w", u.ID, err)
 		}
-		result[row.ListenerID] = append(result[row.ListenerID], Credential{Password: password, UUID: u.UUID})
+		result[row.ListenerID] = append(result[row.ListenerID], Credential{
+			Username: u.Username,
+			Password: password,
+			UUID:     u.UUID,
+		})
 	}
 	return result, nil
 }
@@ -277,24 +257,27 @@ type SafeUser struct {
 	Online        bool       `json:"online"`
 	ExpireTime    time.Time  `json:"expire_time"`
 	Enabled       bool       `json:"enabled"`
-	// Blocked reports whether enforcement currently excludes this user's
-	// credentials from generated Mihomo config (mirrors IsCredentialActive).
-	Blocked bool `json:"blocked"`
+	Blocked       bool       `json:"blocked"`
 }
 
 func ToSafeUser(u *models.ProxyUser) SafeUser {
 	return SafeUser{
-		ID: u.ID, Username: u.Username, UUIDMasked: safeMask(u.UUID),
-		TrafficLimit: u.TrafficLimit, TrafficUsed: u.TrafficUsed,
-		UploadBytes: u.UploadBytes, DownloadBytes: u.DownloadBytes,
-		LastSeen: u.LastSeen, Online: u.Online,
-		ExpireTime: u.ExpireTime, Enabled: u.Enabled,
-		Blocked: !IsCredentialActive(*u),
+		ID:            u.ID,
+		Username:      u.Username,
+		UUIDMasked:    safeMask(u.UUID),
+		TrafficLimit:  u.TrafficLimit,
+		TrafficUsed:   u.TrafficUsed,
+		UploadBytes:   u.UploadBytes,
+		DownloadBytes: u.DownloadBytes,
+		LastSeen:      u.LastSeen,
+		Online:        u.Online,
+		ExpireTime:    u.ExpireTime,
+		Enabled:       u.Enabled,
+		Blocked:       !IsCredentialActive(*u),
 	}
 }
 
 func encryptPassword(plain string) (string, error) { return security.Encrypt(plain) }
-
 func decryptPassword(encoded string) (string, error) { return security.Decrypt(encoded) }
 
 func newUUID() (string, error) {
@@ -304,14 +287,5 @@ func newUUID() (string, error) {
 	}
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
-}
-
-func randomToken(n int) (string, error) {
-	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,6 +12,25 @@ import (
 	"github.com/dzx941/3m-ui/backend/internal/security"
 	"gorm.io/gorm"
 )
+
+type Service struct {
+	db *gorm.DB
+}
+
+var GlobalService *Service
+
+func InitService(db *gorm.DB) {
+	GlobalService = &Service{db: db}
+}
+
+type CreateInput struct {
+	Username     string     `json:"username" binding:"required"`
+	Password     string     `json:"password"`
+	UUID         string     `json:"uuid"`
+	TrafficLimit int64      `json:"traffic_limit"`
+	ExpireTime   *time.Time `json:"expire_time"`
+	Enabled      *bool      `json:"enabled"`
+}
 
 type UpdateInput struct {
 	Username     string     `json:"username"`
@@ -262,18 +282,12 @@ type SafeUser struct {
 
 func ToSafeUser(u *models.ProxyUser) SafeUser {
 	return SafeUser{
-		ID:            u.ID,
-		Username:      u.Username,
-		UUIDMasked:    safeMask(u.UUID),
-		TrafficLimit:  u.TrafficLimit,
-		TrafficUsed:   u.TrafficUsed,
-		UploadBytes:   u.UploadBytes,
-		DownloadBytes: u.DownloadBytes,
-		LastSeen:      u.LastSeen,
-		Online:        u.Online,
-		ExpireTime:    u.ExpireTime,
-		Enabled:       u.Enabled,
-		Blocked:       !IsCredentialActive(*u),
+		ID: u.ID, Username: u.Username, UUIDMasked: safeMask(u.UUID),
+		TrafficLimit: u.TrafficLimit, TrafficUsed: u.TrafficUsed,
+		UploadBytes: u.UploadBytes, DownloadBytes: u.DownloadBytes,
+		LastSeen: u.LastSeen, Online: u.Online,
+		ExpireTime: u.ExpireTime, Enabled: u.Enabled,
+		Blocked: !IsCredentialActive(*u),
 	}
 }
 
@@ -288,4 +302,12 @@ func newUUID() (string, error) {
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+func randomToken(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/frontend/src/components/protocols/ProtocolForm.tsx
+++ b/frontend/src/components/protocols/ProtocolForm.tsx
@@ -1,19 +1,40 @@
 import React from 'react';
-import type { Protocol } from './types';
-import { Hysteria2Form, ShadowsocksForm, TrojanForm, TuicForm, VlessForm, VmessForm, WireGuardForm } from './forms';
+import type { ListenerProtocol } from './types';
+import {
+  AnyTLSForm,
+  Hysteria2Form,
+  Hysteria2RealmForm,
+  MieruForm,
+  ShadowsocksForm,
+  ShadowQuicForm,
+  SnellForm,
+  SudokuForm,
+  TrojanForm,
+  TrustTunnelForm,
+  TuicForm,
+  VlessForm,
+  VmessForm,
+} from './forms';
 
-const forms: Record<Protocol, React.ComponentType> = {
+const forms: Record<ListenerProtocol, React.ComponentType> = {
   shadowsocks: ShadowsocksForm,
+  snell: SnellForm,
   vmess: VmessForm,
   vless: VlessForm,
   trojan: TrojanForm,
   hysteria2: Hysteria2Form,
-  wireguard: WireGuardForm,
+  'hysteria2-realm': Hysteria2RealmForm,
   tuic: TuicForm,
+  shadowquic: ShadowQuicForm,
+  anytls: AnyTLSForm,
+  mieru: MieruForm,
+  sudoku: SudokuForm,
+  trusttunnel: TrustTunnelForm,
 };
 
 const ProtocolForm: React.FC<{ protocol?: string }> = ({ protocol }) => {
-  const Component = forms[(protocol || 'shadowsocks') as Protocol] || ShadowsocksForm;
+  const Component = forms[(protocol || 'shadowsocks') as ListenerProtocol] || ShadowsocksForm;
   return <Component />;
 };
+
 export default ProtocolForm;

--- a/frontend/src/components/protocols/forms.tsx
+++ b/frontend/src/components/protocols/forms.tsx
@@ -1,126 +1,245 @@
 import { Form, Input, InputNumber, Select, Switch } from 'antd';
 
+const field = (name: string, label: string, placeholder?: string) => (
+  <Form.Item name={['protocolConfig', name]} label={label}>
+    <Input placeholder={placeholder} />
+  </Form.Item>
+);
+
+const passwordField = (name: string, label: string, placeholder?: string) => (
+  <Form.Item name={['protocolConfig', name]} label={label}>
+    <Input.Password placeholder={placeholder} />
+  </Form.Item>
+);
+
+const numberField = (name: string, label: string, min?: number, max?: number) => (
+  <Form.Item name={['protocolConfig', name]} label={label}>
+    <InputNumber min={min} max={max} style={{ width: '100%' }} />
+  </Form.Item>
+);
+
+const boolField = (name: string, label: string) => (
+  <Form.Item name={['protocolConfig', name]} label={label} valuePropName="checked">
+    <Switch checkedChildren="Enabled" unCheckedChildren="Disabled" />
+  </Form.Item>
+);
+
+const selectField = (name: string, label: string, options: string[]) => (
+  <Form.Item name={['protocolConfig', name]} label={label}>
+    <Select allowClear options={options.map((value) => ({ value, label: value }))} />
+  </Form.Item>
+);
+
+const tagsField = (name: string, label: string, options: string[] = []) => (
+  <Form.Item name={['protocolConfig', name]} label={label}>
+    <Select mode="tags" options={options.map((value) => ({ value, label: value }))} />
+  </Form.Item>
+);
+
+const jsonField = (name: string, label: string, placeholder: string) => (
+  <Form.Item name={['protocolConfig', name]} label={label}>
+    <Input.TextArea rows={6} placeholder={placeholder} />
+  </Form.Item>
+);
+
+const TLSFields = ({ allowInsecure = false }: { allowInsecure?: boolean }) => (
+  <>
+    {field('certificate', 'Certificate', '/etc/3m-ui/certs/server.crt')}
+    {passwordField('private-key', 'Private Key', '/etc/3m-ui/certs/server.key')}
+    {selectField('client-auth-type', 'Client Auth Type', ['', 'request', 'require-any', 'verify-if-given', 'require-and-verify'])}
+    {field('client-auth-cert', 'Client Auth Certificate')}
+    {field('ech-key', 'ECH Key')}
+    {allowInsecure && boolField('allow-insecure', 'Allow Insecure')}
+  </>
+);
+
+const MuxField = () => jsonField('mux-option', 'MUX Option (JSON)', '{"padding":true,"brutal":{"enabled":true,"up":1000,"down":1000}}');
+
 export const ShadowsocksForm = () => (
   <>
-    <Form.Item name={['protocolConfig', 'cipher']} label="加密算法">
-      <Select options={[{ value: 'aes-256-gcm' }, { value: 'chacha20-ietf-poly1305' }, { value: '2022-blake3-aes-256-gcm' }]} />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'password']} label="密码">
-      <Input.Password />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'plugin']} label="插件">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'plugin-opts']} label="插件参数">
-      <Input.TextArea rows={2} />
-    </Form.Item>
+    {selectField('cipher', 'Cipher', ['2022-blake3-aes-128-gcm', '2022-blake3-aes-256-gcm', '2022-blake3-chacha20-poly1305', 'none', 'aes-128-gcm', 'aes-192-gcm', 'aes-256-gcm', 'chacha20-ietf-poly1305', 'xchacha20-ietf-poly1305'])}
+    {passwordField('password', 'Password')}
+    {boolField('udp', 'UDP')}
+    {jsonField('simple-obfs', 'Simple Obfs (JSON)', '{"enable":true,"mode":"http"}')}
+    {jsonField('shadow-tls', 'ShadowTLS (JSON)', '{"enable":true,"version":3,"handshake":{"dest":"example.com:443"}}')}
+    {jsonField('res-tls', 'ResTLS (JSON)', '{"enable":true,"dest":"example.com:443","password":"..."}')}
+    {jsonField('jls-config', 'JLS Config (JSON)', '{"enable":true,"dest":"example.com:443"}')}
+    {jsonField('kcp-tun', 'KCP Tunnel (JSON)', '{"enable":false,"key":"...","crypt":"aes","mode":"fast"}')}
+    {MuxField()}
+  </>
+);
+
+export const SnellForm = () => (
+  <>
+    {passwordField('psk', 'PSK')}
+    {numberField('version', 'Version', 1, 5)}
+    {boolField('udp', 'UDP')}
+    {jsonField('obfs-opts', 'Obfs Options (JSON)', '{"mode":"http","host":"bing.com"}')}
+    {jsonField('shadow-tls', 'ShadowTLS (JSON)', '{"enable":true,"version":3,"password":"..."}')}
+    {jsonField('res-tls', 'ResTLS (JSON)', '{"enable":true,"dest":"example.com:443","password":"..."}')}
+    {jsonField('jls-config', 'JLS Config (JSON)', '{"enable":true,"dest":"example.com:443"}')}
   </>
 );
 
 export const VmessForm = () => (
   <>
-    <Form.Item name={['protocolConfig', 'uuid']} label="UUID">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'alterId']} label="Alter ID">
-      <InputNumber min={0} style={{ width: '100%' }} />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'cipher']} label="加密算法">
-      <Select options={[{ value: 'auto' }, { value: 'zero' }, { value: 'aes-128-gcm' }, { value: 'chacha20-poly1305' }]} />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'network']} label="传输方式">
-      <Select options={[{ value: 'tcp' }, { value: 'ws' }, { value: 'grpc' }, { value: 'h2' }]} />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'tls']} label="TLS" valuePropName="checked">
-      <Switch />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'servername']} label="服务器名称">
-      <Input />
-    </Form.Item>
+    {jsonField('users', 'Users (JSON)', '[{"username":"user","uuid":"...","alterId":0}]')}
+    {field('ws-path', 'WebSocket Path', '/')}
+    {field('grpc-service-name', 'gRPC Service Name', 'GunService')}
+    {jsonField('mekya-config', 'Mekya Config (JSON)', '{"enable":true}')}
+    {jsonField('mkcp-config', 'mKCP Config (JSON)', '{"enable":true,"mtu":1350}')}
+    {jsonField('jls-config', 'JLS Config (JSON)', '{"enable":true,"dest":"example.com:443"}')}
+    {jsonField('shadow-tls', 'ShadowTLS (JSON)', '{"enable":true,"version":3}')}
+    {jsonField('res-tls', 'ResTLS (JSON)', '{"enable":true,"dest":"example.com:443","password":"..."}')}
+    {jsonField('reality-config', 'Reality Config (JSON)', '{"dest":"example.com:443","private-key":"...","short-id":["0123456789abcdef"],"server-names":["example.com"]}')}
+    {jsonField('tlsmirror-config', 'TLS Mirror Config (JSON)', '{"dest":"example.com:443","primary-key":"..."}')}
+    <TLSFields />
+    {MuxField()}
   </>
 );
 
 export const VlessForm = () => (
   <>
-    <Form.Item name={['protocolConfig', 'uuid']} label="UUID">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'flow']} label="Flow">
-      <Input placeholder="xtls-rprx-vision" />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'encryption']} label="加密">
-      <Input placeholder="none" />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'reality']} label="Reality" valuePropName="checked">
-      <Switch />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'tls']} label="TLS" valuePropName="checked">
-      <Switch />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'network']} label="传输方式">
-      <Select options={[{ value: 'tcp' }, { value: 'ws' }, { value: 'grpc' }]} />
-    </Form.Item>
+    {jsonField('users', 'Users (JSON)', '[{"username":"user","uuid":"...","flow":"xtls-rprx-vision"}]')}
+    {field('ws-path', 'WebSocket Path', '/')}
+    {field('grpc-service-name', 'gRPC Service Name', 'GunService')}
+    {jsonField('xhttp-config', 'XHTTP Config (JSON)', '{"path":"/","host":"","mode":"auto"}')}
+    {field('decryption', 'Decryption')}
+    {jsonField('reality-config', 'Reality Config (JSON)', '{"dest":"example.com:443","private-key":"...","short-id":["0123456789abcdef"],"server-names":["example.com"]}')}
+    {jsonField('shadow-tls', 'ShadowTLS (JSON)', '{"enable":true,"version":3}')}
+    {jsonField('res-tls', 'ResTLS (JSON)', '{"enable":true,"dest":"example.com:443","password":"..."}')}
+    {jsonField('jls-config', 'JLS Config (JSON)', '{"enable":true,"dest":"example.com:443"}')}
+    <TLSFields allowInsecure />
+    {MuxField()}
   </>
 );
 
 export const TrojanForm = () => (
   <>
-    <Form.Item name={['protocolConfig', 'password']} label="密码">
-      <Input.Password />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'sni']} label="SNI">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'tls']} label="TLS" valuePropName="checked">
-      <Switch />
-    </Form.Item>
+    {jsonField('users', 'Users (JSON)', '[{"username":"user","password":"password"}]')}
+    {field('ws-path', 'WebSocket Path', '/')}
+    {field('grpc-service-name', 'gRPC Service Name', 'GunService')}
+    {jsonField('reality-config', 'Reality Config (JSON)', '{"dest":"example.com:443","private-key":"...","short-id":["0123456789abcdef"],"server-names":["example.com"]}')}
+    {jsonField('shadow-tls', 'ShadowTLS (JSON)', '{"enable":true,"version":3}')}
+    {jsonField('res-tls', 'ResTLS (JSON)', '{"enable":true,"dest":"example.com:443","password":"..."}')}
+    {jsonField('jls-config', 'JLS Config (JSON)', '{"enable":true,"dest":"example.com:443"}')}
+    {jsonField('ss-option', 'Shadowsocks Option (JSON)', '{"enabled":true,"method":"aes-128-gcm","password":"..."}')}
+    <TLSFields allowInsecure />
+    {MuxField()}
   </>
 );
 
 export const Hysteria2Form = () => (
   <>
-    <Form.Item name={['protocolConfig', 'password']} label="密码">
-      <Input.Password />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'obfs']} label="混淆">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'up']} label="上传速度">
-      <Input placeholder="100 Mbps" />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'down']} label="下载速度">
-      <Input placeholder="100 Mbps" />
-    </Form.Item>
+    {jsonField('users', 'Users (JSON)', '{"user":"password"}')}
+    {field('up', 'Upload Speed (Mbps)', '1000')}
+    {field('down', 'Download Speed (Mbps)', '1000')}
+    {boolField('ignore-client-bandwidth', 'Ignore Client Bandwidth')}
+    {selectField('obfs', 'Obfuscation', ['salamander'])}
+    {passwordField('obfs-password', 'Obfuscation Password')}
+    {field('masquerade', 'Masquerade', 'https://example.com')}
+    {field('bbr-profile', 'BBR Profile')}
+    {jsonField('realm-opts', 'Realm Options (JSON)', '{"enable":true,"server-url":"https://example.com","token":"public","realm-id":"my-realm"}')}
+    {tagsField('alpn', 'ALPN', ['h3'])}
+    <TLSFields />
+    {MuxField()}
   </>
 );
 
-export const WireGuardForm = () => (
+export const Hysteria2RealmForm = () => (
   <>
-    <Form.Item name={['protocolConfig', 'private-key']} label="私钥">
-      <Input.Password />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'public-key']} label="公钥">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'ip']} label="IP 地址">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'mtu']} label="MTU">
-      <InputNumber min={576} max={9000} style={{ width: '100%' }} />
-    </Form.Item>
+    {passwordField('token', 'Bearer Token', 'public')}
+    {numberField('max-realms', 'Max Realms', 0)}
+    {numberField('max-realms-per-ip', 'Max Realms Per IP', 0)}
+    {field('trusted-proxy-header', 'Trusted Proxy Header', 'X-Forwarded-For')}
+    {field('realm-name-pattern', 'Realm Name Pattern', '^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')}
+    <TLSFields />
+    {tagsField('alpn', 'ALPN', ['h2', 'http/1.1'])}
   </>
 );
 
 export const TuicForm = () => (
   <>
-    <Form.Item name={['protocolConfig', 'uuid']} label="UUID">
-      <Input />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'password']} label="密码">
-      <Input.Password />
-    </Form.Item>
-    <Form.Item name={['protocolConfig', 'congestion-controller']} label="拥塞控制">
-      <Select options={[{ value: 'cubic' }, { value: 'bbr' }, { value: 'new_reno' }]} />
-    </Form.Item>
+    {jsonField('users', 'Users (JSON, TUIC V5)', '{"00000000-0000-0000-0000-000000000001":"password"}')}
+    {jsonField('token', 'Token (JSON, TUIC V4)', '["TOKEN"]')}
+    <TLSFields />
+    {selectField('congestion-controller', 'Congestion Controller', ['cubic', 'new_reno', 'bbr'])}
+    {field('bbr-profile', 'BBR Profile')}
+    {numberField('max-idle-time', 'Max Idle Time (ms)', 0)}
+    {numberField('authentication-timeout', 'Authentication Timeout (ms)', 0)}
+    {tagsField('alpn', 'ALPN', ['h3'])}
+    {numberField('max-udp-relay-packet-size', 'Max UDP Relay Packet Size', 1, 65535)}
+    {MuxField()}
+  </>
+);
+
+export const ShadowQuicForm = () => (
+  <>
+    {jsonField('users', 'Users (JSON)', '[{"username":"user","password":"password"}]')}
+    {jsonField('jls-upstream', 'JLS Upstream (JSON)', '{"addr":"www.example.com:443","sni":"example.com","rate-limit":0}')}
+    {tagsField('alpn', 'ALPN', ['h3'])}
+    {tagsField('quic-versions', 'QUIC Versions', ['v1', 'v2'])}
+    {boolField('zero-rtt', 'Zero RTT')}
+    {selectField('congestion-controller', 'Congestion Controller', ['cubic', 'new_reno', 'bbr'])}
+    {field('up', 'Upload Speed')}
+    {field('down', 'Download Speed')}
+    {boolField('ignore-client-bandwidth', 'Ignore Client Bandwidth')}
+    {numberField('cwnd', 'CWND', 1)}
+    {field('bbr-profile', 'BBR Profile')}
+    {numberField('max-idle-time', 'Max Idle Time (ms)', 0)}
+    {numberField('max-datagram-frame-size', 'Max Datagram Frame Size', 1, 65535)}
+    {numberField('recv-window-conn', 'Receive Window Conn', 0)}
+    {numberField('recv-window', 'Receive Window', 0)}
+    {boolField('disable-mtu-discovery', 'Disable MTU Discovery')}
+  </>
+);
+
+export const AnyTLSForm = () => (
+  <>
+    {jsonField('users', 'Users (JSON)', '{"username":"password"}')}
+    <TLSFields allowInsecure />
+    {jsonField('shadow-tls', 'ShadowTLS (JSON)', '{"enable":true,"version":3,"handshake":{"dest":"example.com:443"}}')}
+    {jsonField('res-tls', 'ResTLS (JSON)', '{"enable":true,"dest":"example.com:443","password":"..."}')}
+    {jsonField('jls-config', 'JLS Config (JSON)', '{"enable":true,"dest":"example.com:443"}')}
+    {field('padding-scheme', 'Padding Scheme')}
+  </>
+);
+
+export const MieruForm = () => (
+  <>
+    {selectField('transport', 'Transport', ['TCP', 'UDP'])}
+    {jsonField('users', 'Users (JSON)', '{"username":"password"}')}
+    {field('traffic-pattern', 'Traffic Pattern (Base64)')}
+    {boolField('user-hint-is-mandatory', 'User Hint Is Mandatory')}
+  </>
+);
+
+export const SudokuForm = () => (
+  <>
+    {field('key', 'Server Key')}
+    {selectField('aead-method', 'AEAD Method', ['chacha20-poly1305', 'aes-128-gcm', 'none'])}
+    {numberField('padding-min', 'Padding Min', 0, 100)}
+    {numberField('padding-max', 'Padding Max', 0, 100)}
+    {selectField('table-type', 'Table Type', ['prefer_ascii', 'prefer_entropy', 'up_ascii_down_entropy', 'up_entropy_down_ascii'])}
+    {field('custom-table', 'Custom Table')}
+    {tagsField('custom-tables', 'Custom Tables')}
+    {numberField('handshake-timeout', 'Handshake Timeout', 0)}
+    {boolField('enable-pure-downlink', 'Pure Downlink')}
+    {jsonField('httpmask', 'HTTPMask (JSON)', '{"disable":false,"mode":"legacy","path-root":""}')}
+    {boolField('disable-http-mask', 'Disable HTTP Mask')}
+    {selectField('http-mask-mode', 'HTTP Mask Mode', ['legacy', 'stream', 'poll', 'auto', 'ws'])}
+    {field('path-root', 'HTTP Mask Path Root')}
+    {field('fallback', 'Fallback Address')}
+    {MuxField()}
+  </>
+);
+
+export const TrustTunnelForm = () => (
+  <>
+    {jsonField('users', 'Users (JSON)', '[{"username":"user","password":"password"}]')}
+    <TLSFields />
+    {tagsField('network', 'Network', ['tcp', 'udp'])}
+    {selectField('congestion-controller', 'Congestion Controller', ['cubic', 'new_reno', 'bbr'])}
+    {field('bbr-profile', 'BBR Profile')}
   </>
 );

--- a/frontend/src/components/protocols/types.ts
+++ b/frontend/src/components/protocols/types.ts
@@ -1,23 +1,50 @@
-export type Protocol = 'shadowsocks' | 'vmess' | 'vless' | 'trojan' | 'hysteria2' | 'wireguard' | 'tuic';
+export type ListenerProtocol =
+  | 'shadowsocks'
+  | 'snell'
+  | 'vmess'
+  | 'vless'
+  | 'trojan'
+  | 'hysteria2'
+  | 'hysteria2-realm'
+  | 'tuic'
+  | 'shadowquic'
+  | 'anytls'
+  | 'mieru'
+  | 'sudoku'
+  | 'trusttunnel';
+
+export type Protocol = ListenerProtocol;
+
+export const LISTENER_PROTOCOLS: ListenerProtocol[] = [
+  'shadowsocks',
+  'snell',
+  'vmess',
+  'vless',
+  'trojan',
+  'hysteria2',
+  'hysteria2-realm',
+  'tuic',
+  'shadowquic',
+  'anytls',
+  'mieru',
+  'sudoku',
+  'trusttunnel',
+];
 
 export interface ProxyNode {
   id?: string;
   name: string;
-  type: Protocol;
+  type: ListenerProtocol;
   server: string;
   port: number;
-
   uuid?: string;
   password?: string;
   cipher?: string;
-
   tls?: boolean;
   sni?: string;
   servername?: string;
-
   flow?: string;
   path?: string;
   host?: string;
-
   [key: string]: unknown;
 }

--- a/frontend/src/pages/Listeners.tsx
+++ b/frontend/src/pages/Listeners.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Typography,
   Table,
@@ -19,6 +19,7 @@ import {
 import { PlusOutlined, EditOutlined, DeleteOutlined, ReloadOutlined, CopyOutlined } from '@ant-design/icons';
 import { apiRequest } from '../api/request';
 import { ProtocolForm } from '../components/protocols';
+import { LISTENER_PROTOCOLS, type ListenerProtocol } from '../components/protocols/types';
 
 const { Title, Paragraph } = Typography;
 
@@ -67,6 +68,28 @@ interface ClientAccess {
   shadowrocket_link: string;
 }
 
+const protocolLabels: Record<ListenerProtocol, string> = {
+  shadowsocks: 'Shadowsocks',
+  snell: 'Snell',
+  vmess: 'VMess',
+  vless: 'VLESS',
+  trojan: 'Trojan',
+  hysteria2: 'Hysteria 2',
+  'hysteria2-realm': 'Hysteria 2 Realm',
+  tuic: 'TUIC (V4/V5)',
+  shadowquic: 'ShadowQUIC',
+  anytls: 'AnyTLS',
+  mieru: 'Mieru',
+  sudoku: 'Sudoku',
+  trusttunnel: 'TrustTunnel',
+};
+
+const JSON_CONFIG_FIELDS = new Set([
+  'users', 'simple-obfs', 'shadow-tls', 'res-tls', 'jls-config', 'kcp-tun',
+  'obfs-opts', 'mekya-config', 'mkcp-config', 'reality-config', 'tlsmirror-config',
+  'xhttp-config', 'ss-option', 'realm-opts', 'mux-option', 'jls-upstream', 'httpmask', 'token',
+]);
+
 const formatBytes = (bytes: number): string => {
   if (!bytes) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -74,7 +97,7 @@ const formatBytes = (bytes: number): string => {
   let i = 0;
   while (value >= 1024 && i < units.length - 1) {
     value /= 1024;
-    i++;
+    i += 1;
   }
   return `${value.toFixed(value >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
 };
@@ -88,7 +111,7 @@ const ListenersPage: React.FC = () => {
   const [clientModalOpen, setClientModalOpen] = useState(false);
   const [form] = Form.useForm();
   const [trafficByListener, setTrafficByListener] = useState<Record<number, ListenerTrafficStats>>({});
-  const selectedProtocol = Form.useWatch('protocol', form);
+  const selectedProtocol = Form.useWatch('protocol', form) as ListenerProtocol | undefined;
 
   const fetchNodes = async () => {
     setLoading(true);
@@ -134,8 +157,6 @@ const ListenersPage: React.FC = () => {
       bind_address: '0.0.0.0',
       port: 10086,
       protocol: 'shadowsocks',
-      tls: false,
-      udp: true,
       enabled: true,
       protocolConfig: {},
     });
@@ -146,15 +167,17 @@ const ListenersPage: React.FC = () => {
     setEditingRecord(record);
     form.resetFields();
     let protocolConfig: Record<string, unknown> = {};
-    let flow = '';
     try {
-      const parsed = JSON.parse(record.config || '{}');
-      if (parsed.flow) flow = parsed.flow;
-      protocolConfig = { ...parsed };
+      protocolConfig = JSON.parse(record.config || '{}');
+      for (const key of JSON_CONFIG_FIELDS) {
+        if (protocolConfig[key] !== undefined && typeof protocolConfig[key] !== 'string') {
+          protocolConfig[key] = JSON.stringify(protocolConfig[key], null, 2);
+        }
+      }
     } catch {
-      // Keep the form usable for legacy malformed records.
+      protocolConfig = {};
     }
-    form.setFieldsValue({ ...record, flow, protocolConfig });
+    form.setFieldsValue({ ...record, protocolConfig });
     setModalOpen(true);
   };
 
@@ -196,17 +219,31 @@ const ListenersPage: React.FC = () => {
       setClientAccess(access);
       setClientModalOpen(true);
     } catch (error: unknown) {
-      message.error(error instanceof Error ? error.message : 'Failed to generate client configuration.');
+      message.error(error instanceof Error ? error.message : 'This listener does not have a client proxy representation.');
     }
   };
 
   const handleFormSubmit = async () => {
     try {
       const values = await form.validateFields();
-      const configObj: Record<string, unknown> = values.protocolConfig || {};
-      if (values.flow) configObj.flow = values.flow;
+      const configObj: Record<string, unknown> = { ...(values.protocolConfig || {}) };
+      for (const key of JSON_CONFIG_FIELDS) {
+        const value = configObj[key];
+        if (typeof value === 'string' && value.trim() !== '') {
+          try {
+            configObj[key] = JSON.parse(value);
+          } catch {
+            message.error(`${key} must contain valid JSON.`);
+            return;
+          }
+        }
+      }
+
       const payload = {
         ...values,
+        protocol: values.protocol,
+        type: values.protocol,
+        listen: values.bind_address,
         config: JSON.stringify(configObj),
         status: values.enabled ? 'active' : 'inactive',
       };
@@ -218,9 +255,10 @@ const ListenersPage: React.FC = () => {
       setModalOpen(false);
       void fetchNodes();
 
-      // A new listener immediately receives a listener-bound client access token.
-      if (!editingRecord && created?.ID) {
+      if (!editingRecord && created?.ID && values.protocol !== 'hysteria2-realm') {
         await generateClientAccess(created.ID);
+      } else if (!editingRecord && values.protocol === 'hysteria2-realm') {
+        message.info('Hysteria 2 Realm is an auxiliary realm service, not a client proxy node; no client link is generated.');
       }
     } catch {
       // Validation or API failure is already surfaced by the form/request layer.
@@ -239,28 +277,15 @@ const ListenersPage: React.FC = () => {
   const columns = [
     { title: 'ID', dataIndex: 'ID', key: 'ID', width: 60 },
     { title: 'Name', dataIndex: 'name', key: 'name' },
-    { title: 'Listener Type', dataIndex: 'protocol', key: 'protocol', render: (proto: string) => <Tag color="blue">{proto}</Tag> },
+    { title: 'Listener Type', dataIndex: 'protocol', key: 'protocol', render: (proto: string) => <Tag color="blue">{protocolLabels[proto as ListenerProtocol] || proto}</Tag> },
     { title: 'Port', dataIndex: 'port', key: 'port' },
-    { title: 'TLS', dataIndex: 'tls', key: 'tls', render: (tls: boolean) => (tls ? <Tag color="green">TLS</Tag> : <Tag>Plain</Tag>) },
+    { title: 'Connections', key: 'connections', render: (_: unknown, record: NodeRecord) => <Tag color={trafficByListener[record.ID]?.connections ? 'blue' : 'default'}>{trafficByListener[record.ID]?.connections || 0}</Tag> },
+    { title: 'Traffic', key: 'traffic', render: (_: unknown, record: NodeRecord) => <span>↑ {formatBytes(trafficByListener[record.ID]?.upload || 0)} &nbsp; ↓ {formatBytes(trafficByListener[record.ID]?.download || 0)}</span> },
+    { title: 'Status', dataIndex: 'enabled', key: 'enabled', render: (enabled: boolean, record: NodeRecord) => <Switch checked={enabled} onChange={(checked) => void handleToggleEnabled(record, checked)} checkedChildren="On" unCheckedChildren="Off" /> },
     {
-      title: 'Connections', key: 'connections', render: (_: unknown, record: NodeRecord) => {
-        const stats = trafficByListener[record.ID];
-        return <Tag color={stats?.connections ? 'blue' : 'default'}>{stats?.connections || 0}</Tag>;
-      },
-    },
-    {
-      title: 'Traffic', key: 'traffic', render: (_: unknown, record: NodeRecord) => {
-        const stats = trafficByListener[record.ID];
-        return <span>↑ {formatBytes(stats?.upload || 0)} &nbsp; ↓ {formatBytes(stats?.download || 0)}</span>;
-      },
-    },
-    {
-      title: 'Status', dataIndex: 'enabled', key: 'enabled', render: (enabled: boolean, record: NodeRecord) => (
-        <Switch checked={enabled} onChange={(checked) => void handleToggleEnabled(record, checked)} checkedChildren="On" unCheckedChildren="Off" />
-      ),
-    },
-    {
-      title: 'Actions', key: 'actions', render: (_: unknown, record: NodeRecord) => (
+      title: 'Actions',
+      key: 'actions',
+      render: (_: unknown, record: NodeRecord) => (
         <Space size="middle">
           <Button type="text" icon={<CopyOutlined style={{ color: '#722ed1' }} />} onClick={() => void generateClientAccess(record.ID)} title="Generate Client Link" />
           <Button type="text" icon={<ReloadOutlined style={{ color: '#52c41a' }} />} onClick={() => void handleReload(record.ID)} title="Hot Reload" />
@@ -286,31 +311,28 @@ const ListenersPage: React.FC = () => {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
         <div>
           <Title level={2} style={{ margin: 0 }}>Mihomo Listeners</Title>
-          <Paragraph style={{ margin: 0 }}>Create Mihomo listeners and immediately generate client configuration links.</Paragraph>
+          <Paragraph style={{ margin: 0 }}>Create supported Mihomo listeners and generate matching client configuration links.</Paragraph>
         </div>
         <Button type="primary" icon={<PlusOutlined />} onClick={handleOpenAdd}>Add Listener</Button>
       </div>
 
       <Table dataSource={data} columns={columns} rowKey="ID" loading={loading} scroll={{ x: 'max-content' }} locale={{ emptyText: 'No listeners found. Create one to get started.' }} />
 
-      <Modal title={editingRecord ? 'Edit Listener' : 'Add Listener'} open={modalOpen} onOk={() => void handleFormSubmit()} onCancel={() => setModalOpen(false)} destroyOnClose width={600}>
+      <Modal title={editingRecord ? 'Edit Listener' : 'Add Listener'} open={modalOpen} onOk={() => void handleFormSubmit()} onCancel={() => setModalOpen(false)} destroyOnClose width={760}>
         <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item name="name" label="Name" rules={[{ required: true, message: 'Please input listener name' }]}>
-            <Input placeholder="e.g. hk-shadowsocks" />
+            <Input placeholder="e.g. vless-reality" />
           </Form.Item>
 
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item name="protocol" label="Listener Type" rules={[{ required: true, message: 'Select listener type' }]}>
-                <Select placeholder="Choose listener type" onChange={() => form.setFieldsValue({ protocolConfig: {} })}>
-                  <Select.Option value="shadowsocks">Shadowsocks</Select.Option>
-                  <Select.Option value="vmess">VMess</Select.Option>
-                  <Select.Option value="vless">VLESS</Select.Option>
-                  <Select.Option value="trojan">Trojan</Select.Option>
-                  <Select.Option value="hysteria2">Hysteria 2</Select.Option>
-                  <Select.Option value="tuic">TUIC</Select.Option>
-                  <Select.Option value="wireguard">WireGuard</Select.Option>
-                </Select>
+                <Select
+                  showSearch
+                  optionFilterProp="label"
+                  options={LISTENER_PROTOCOLS.map((protocol) => ({ value: protocol, label: protocolLabels[protocol] }))}
+                  onChange={() => form.setFieldsValue({ protocolConfig: {} })}
+                />
               </Form.Item>
             </Col>
             <Col span={12}>
@@ -320,27 +342,17 @@ const ListenersPage: React.FC = () => {
             </Col>
           </Row>
 
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="bind_address" label="Bind Address" rules={[{ required: true, message: 'Please enter bind IP' }]}>
-                <Input placeholder="e.g. 0.0.0.0" />
-              </Form.Item>
-            </Col>
-            <Col span={6}>
-              <Form.Item name="tls" label="TLS" valuePropName="checked"><Switch checkedChildren="Enabled" unCheckedChildren="Disabled" /></Form.Item>
-            </Col>
-            <Col span={6}>
-              <Form.Item name="udp" label="UDP" valuePropName="checked"><Switch checkedChildren="Enabled" unCheckedChildren="Disabled" /></Form.Item>
-            </Col>
-          </Row>
+          <Form.Item name="bind_address" label="Listen Address" rules={[{ required: true, message: 'Please enter listen address' }]}>
+            <Input placeholder="0.0.0.0" />
+          </Form.Item>
 
           <Typography.Paragraph type="secondary">
-            SOCKS, HTTP, TProxy, Redir, Mixed, Tunnel and TUN are not listener choices here. Only listener protocols that can be exported as client proxy configurations are exposed.
+            SOCKS, HTTP, TProxy, Redir, Mixed, Tunnel, TUN and WireGuard are intentionally excluded. They are not part of the listener-to-client distribution model used by this page.
           </Typography.Paragraph>
 
           <ProtocolForm protocol={selectedProtocol} />
 
-          <Form.Item name="enabled" label="Status Enabled" valuePropName="checked">
+          <Form.Item name="enabled" label="Enabled" valuePropName="checked">
             <Switch checkedChildren="On" unCheckedChildren="Off" />
           </Form.Item>
         </Form>


### PR DESCRIPTION
## Summary

Audited the current listener/node configuration against the uploaded official Mihomo documentation and fixed schema mismatches across the backend listener generator, client exporter, and frontend editor.

## Fixed

- Centralized the real distributable listener protocol allowlist:
  - Shadowsocks
  - Snell
  - VMess
  - VLESS
  - Trojan
  - Hysteria2
  - Hysteria2 Realm
  - TUIC V4/V5
  - ShadowQUIC
  - AnyTLS
  - Mieru
  - Sudoku
  - TrustTunnel
- Removed SOCKS, HTTP, TProxy, Redir, Mixed, Tunnel, TUN and WireGuard from the listener editor/distribution model.
- Removed invalid global TLS/UDP fields from the listener form. Protocol-specific fields now control their own schema.
- Added protocol-specific forms for the documented listener-only fields, including nested JSON options such as Reality, ShadowTLS, ResTLS, JLS, XHTTP, HTTPMask, MUX, mKCP and Realm options.
- Fixed the backend listener generator so it emits native Mihomo listener fields instead of client proxy shapes or nested `tls` objects.
- Fixed UDP emission so `udp: true` is not injected into protocols that do not define a listener UDP field.
- Preserved Listener certificate/private-key fields correctly.
- Preserved listener-specific server features instead of accidentally filtering fields such as `reality-config`, `shadow-tls`, `res-tls`, `jls-config`, `xhttp-config`, etc.
- Added credential usernames to generated listener users.
- Fixed soft-deleted listener-user bindings from being treated as active.
- Reworked client export to convert listener schemas into actual Mihomo proxy schemas, including WebSocket/gRPC/XHTTP transport conversion and per-user proxy generation.
- Server certificate/private-key and Reality private-key material is never copied into client profiles.
- Hysteria2 Realm is explicitly rejected as a client proxy export because the official docs define it as an auxiliary realm service rather than a proxy endpoint.
- Added backend tests for schema boundaries, credential generation, extended protocols, excluded protocols, transport conversion and secret non-leakage.

## Source of truth

The uploaded Meta-Docs documentation was used as the schema reference, especially `docs/config/inbound/listeners/*` and the corresponding `docs/config/proxies/*` files.

## Verification

Please run the repository CI checks (`go test ./...`, `go vet ./...`, `pnpm lint`, `pnpm build`) on this PR.