### PR TITLE
fix: repair node client export and mixed-language UI

### DIFF
--- a/backend/internal/node/validator.go
+++ b/backend/internal/node/validator.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -36,6 +38,15 @@ func ValidateNode(l *models.Listener) error {
 	if l.BindAddress == "" {
 		l.BindAddress = "0.0.0.0"
 	}
+
+	// A node is also the source of its client configuration. Protocols that
+	// require credentials therefore receive one stable generated credential
+	// when the form did not provide one. This removes the old dependency on
+	// the separate Proxy User management page.
+	if err := ensureClientCredentials(l); err != nil {
+		return err
+	}
+
 	cfg, err := decodeConfig(l.Config)
 	if err != nil {
 		return err
@@ -44,6 +55,73 @@ func ValidateNode(l *models.Listener) error {
 		return err
 	}
 	return validateProtocolSpecific(proto, cfg)
+}
+
+func ensureClientCredentials(l *models.Listener) error {
+	cfg, err := decodeConfig(l.Config)
+	if err != nil {
+		return err
+	}
+	if requiresUserCredentials(l.Protocol) && !hasExportCredentials(l.Protocol, cfg) {
+		switch strings.ToLower(l.Protocol) {
+		case "vless", "vmess":
+			uuid, err := randomUUID()
+			if err != nil { return fmt.Errorf("generate client uuid: %w", err) }
+			cfg["users"] = []interface{}{map[string]interface{}{
+				"username": "client",
+				"uuid": uuid,
+			}}
+		case "trojan", "hysteria2", "anytls", "mieru", "shadowquic", "tuic":
+			password, err := randomSecret(24)
+			if err != nil { return fmt.Errorf("generate client credential: %w", err) }
+			username := "client"
+			if l.Protocol == "tuic" {
+				username, err = randomUUID()
+				if err != nil { return fmt.Errorf("generate TUIC client uuid: %w", err) }
+			}
+			cfg["users"] = map[string]interface{}{username: password}
+		}
+		encoded, err := json.Marshal(cfg)
+		if err != nil { return fmt.Errorf("encode listener credentials: %w", err) }
+		l.Config = string(encoded)
+	}
+	return nil
+}
+
+func requiresUserCredentials(proto string) bool {
+	switch strings.ToLower(proto) {
+	case "vless", "vmess", "trojan", "hysteria2", "anytls", "mieru", "shadowquic", "tuic":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasExportCredentials(proto string, cfg map[string]interface{}) bool {
+	users, ok := cfg["users"]
+	if !ok || users == nil { return false }
+	switch strings.ToLower(proto) {
+	case "hysteria2", "anytls", "mieru", "tuic":
+		m, ok := users.(map[string]interface{})
+		return ok && len(m) > 0
+	default:
+		list, ok := users.([]interface{})
+		return ok && len(list) > 0
+	}
+}
+
+func randomSecret(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil { return "", err }
+	return hex.EncodeToString(b), nil
+}
+
+func randomUUID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil { return "", err }
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }
 
 func decodeConfig(raw string) (map[string]interface{}, error) {
@@ -80,181 +158,84 @@ func flattenConfig(prefix string, value interface{}, out map[string]interface{})
 	if m, ok := value.(map[string]interface{}); ok {
 		for key, child := range m {
 			next := key
-			if prefix != "" {
-				next = prefix + "." + key
-			}
+			if prefix != "" { next = prefix + "." + key }
 			if childMap, ok := child.(map[string]interface{}); ok {
 				flattenConfig(next, childMap, out)
-			} else {
-				out[next] = child
-			}
+			} else { out[next] = child }
 		}
 		return
 	}
-	if prefix != "" {
-		out[prefix] = value
-	}
+	if prefix != "" { out[prefix] = value }
 }
 
 func validateProtocolSpecific(proto string, cfg map[string]interface{}) error {
-	if err := validateCertificateMode(proto, cfg); err != nil {
-		return err
-	}
+	if err := validateCertificateMode(proto, cfg); err != nil { return err }
 	switch proto {
 	case "snell":
-		if value, ok := numeric(cfg["version"]); ok && (value < 1 || value > 5) {
-			return fmt.Errorf("snell version must be between 1 and 5")
-		}
+		if value, ok := numeric(cfg["version"]); ok && (value < 1 || value > 5) { return fmt.Errorf("snell version must be between 1 and 5") }
 	case "hysteria2":
-		if obfs, ok := cfg["obfs"].(string); ok && obfs != "" && obfs != "salamander" {
-			return fmt.Errorf("hysteria2 obfs must be salamander")
-		}
-		if !hasCertificatePair(cfg) && !boolValue(cfg["allow-insecure"]) {
-			return fmt.Errorf("hysteria2 listener requires certificate/private-key or allow-insecure")
-		}
-		if users, ok := cfg["users"].(map[string]interface{}); ok && len(users) == 0 {
-			return fmt.Errorf("hysteria2 users cannot be empty")
-		}
+		if obfs, ok := cfg["obfs"].(string); ok && obfs != "" && obfs != "salamander" { return fmt.Errorf("hysteria2 obfs must be salamander") }
+		if !hasCertificatePair(cfg) && !boolValue(cfg["allow-insecure"]) { return fmt.Errorf("hysteria2 listener requires certificate/private-key or allow-insecure") }
+		if users, ok := cfg["users"].(map[string]interface{}); ok && len(users) == 0 { return fmt.Errorf("hysteria2 users cannot be empty") }
 	case "anytls":
-		if _, ok := cfg["reality-config"]; ok {
-			return fmt.Errorf("anytls does not support reality-config")
-		}
-		if !hasCertificatePair(cfg) && !boolValue(cfg["allow-insecure"]) {
-			return fmt.Errorf("anytls listener requires certificate/private-key or allow-insecure")
-		}
-		if users, ok := cfg["users"].(map[string]interface{}); ok && len(users) == 0 {
-			return fmt.Errorf("anytls users cannot be empty")
-		}
+		if _, ok := cfg["reality-config"]; ok { return fmt.Errorf("anytls does not support reality-config") }
+		if !hasCertificatePair(cfg) && !boolValue(cfg["allow-insecure"]) { return fmt.Errorf("anytls listener requires certificate/private-key or allow-insecure") }
+		if users, ok := cfg["users"].(map[string]interface{}); ok && len(users) == 0 { return fmt.Errorf("anytls users cannot be empty") }
 	case "trusttunnel":
-		if !hasCertificatePair(cfg) {
-			return fmt.Errorf("trusttunnel listener requires certificate and private-key")
-		}
+		if !hasCertificatePair(cfg) { return fmt.Errorf("trusttunnel listener requires certificate and private-key") }
 	case "tuic":
 		users := hasNonEmpty(cfg["users"])
 		token := hasNonEmpty(cfg["token"])
-		if users == token {
-			return fmt.Errorf("tuic listener must configure exactly one of users (TUIC V5) or token (TUIC V4)")
-		}
+		if users == token { return fmt.Errorf("tuic listener must configure exactly one of users (TUIC V5) or token (TUIC V4)") }
 	case "vless", "vmess":
 		if users, ok := cfg["users"].([]interface{}); ok {
-			for i, user := range users {
-				if err := validateUserRow(proto, i, user, true); err != nil {
-					return err
-				}
-			}
+			for i, user := range users { if err := validateUserRow(proto, i, user, true); err != nil { return err } }
 		}
 	case "trojan", "shadowquic":
 		if users, ok := cfg["users"].([]interface{}); ok {
-			for i, user := range users {
-				if err := validateUserRow(proto, i, user, false); err != nil {
-					return err
-				}
-			}
+			for i, user := range users { if err := validateUserRow(proto, i, user, false); err != nil { return err } }
 		}
 	case "mieru":
-		if users, ok := cfg["users"].(map[string]interface{}); ok && len(users) == 0 {
-			return fmt.Errorf("mieru users cannot be empty")
-		}
+		if users, ok := cfg["users"].(map[string]interface{}); ok && len(users) == 0 { return fmt.Errorf("mieru users cannot be empty") }
 	case "sudoku":
-		min, minOK := numeric(cfg["padding-min"])
-		max, maxOK := numeric(cfg["padding-max"])
-		if minOK && maxOK && max < min {
-			return fmt.Errorf("sudoku padding-max must be greater than or equal to padding-min")
-		}
+		min, minOK := numeric(cfg["padding-min"]); max, maxOK := numeric(cfg["padding-max"])
+		if minOK && maxOK && max < min { return fmt.Errorf("sudoku padding-max must be greater than or equal to padding-min") }
 	}
 	return nil
 }
 
-// validateCertificateMode enforces mutually exclusive TLS modes. A plain
-// certificate/private-key pair, Reality, ShadowTLS/ResTLS/JLS alternatives,
-// and allow-insecure are never silently combined.
 func validateCertificateMode(proto string, cfg map[string]interface{}) error {
 	cert := hasString(cfg["certificate"])
 	key := hasString(cfg["private-key"]) || hasString(cfg["private_key"])
-	if cert != key {
-		return fmt.Errorf("%s listener requires certificate and private-key together", proto)
-	}
-
+	if cert != key { return fmt.Errorf("%s listener requires certificate and private-key together", proto) }
 	modes := make([]string, 0, 5)
-	if cert && key {
-		modes = append(modes, "certificate")
-	}
-	for _, name := range []string{"reality-config", "shadow-tls", "res-tls", "jls-config"} {
-		if hasNonEmpty(cfg[name]) {
-			modes = append(modes, name)
-		}
-	}
-	if len(modes) > 1 {
-		return fmt.Errorf("%s listener has mutually exclusive TLS modes configured: %s", proto, strings.Join(modes, ", "))
-	}
-
-	// AnyTLS explicitly does not support Reality. Other protocols can expose
-	// Reality only when their schema includes reality-config.
-	if proto == "anytls" && hasNonEmpty(cfg["reality-config"]) {
-		return fmt.Errorf("anytls listener does not support reality-config")
-	}
-	if (proto == "anytls" || proto == "hysteria2" || proto == "tuic" || proto == "trusttunnel") &&
-		(hasNonEmpty(cfg["shadow-tls"]) || hasNonEmpty(cfg["res-tls"]) || hasNonEmpty(cfg["jls-config"])) {
-		return fmt.Errorf("%s listener does not support the selected TLS alternative", proto)
-	}
+	if cert && key { modes = append(modes, "certificate") }
+	for _, name := range []string{"reality-config", "shadow-tls", "res-tls", "jls-config"} { if hasNonEmpty(cfg[name]) { modes = append(modes, name) } }
+	if len(modes) > 1 { return fmt.Errorf("%s listener has mutually exclusive TLS modes configured: %s", proto, strings.Join(modes, ", ")) }
+	if proto == "anytls" && hasNonEmpty(cfg["reality-config"]) { return fmt.Errorf("anytls listener does not support reality-config") }
+	if (proto == "anytls" || proto == "hysteria2" || proto == "tuic" || proto == "trusttunnel") && (hasNonEmpty(cfg["shadow-tls"]) || hasNonEmpty(cfg["res-tls"]) || hasNonEmpty(cfg["jls-config"])) { return fmt.Errorf("%s listener does not support the selected TLS alternative", proto) }
 	return nil
 }
 
 func validateUserRow(proto string, index int, raw interface{}, uuidMode bool) error {
 	row, ok := raw.(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("%s listener users[%d] must be an object", proto, index)
-	}
-	if !hasString(row["username"]) {
-		return fmt.Errorf("%s listener users[%d] requires username", proto, index)
-	}
+	if !ok { return fmt.Errorf("%s listener users[%d] must be an object", proto, index) }
+	if !hasString(row["username"]) { return fmt.Errorf("%s listener users[%d] requires username", proto, index) }
 	if uuidMode {
-		if !hasString(row["uuid"]) {
-			return fmt.Errorf("%s listener users[%d] requires uuid", proto, index)
-		}
-		if proto == "vmess" && hasNonEmpty(row["flow"]) {
-			return fmt.Errorf("vmess listener users[%d] does not support flow", index)
-		}
-		if proto == "vless" && hasNonEmpty(row["alterId"]) {
-			return fmt.Errorf("vless listener users[%d] does not support alterId", index)
-		}
-	} else if !hasString(row["password"]) {
-		return fmt.Errorf("%s listener users[%d] requires password", proto, index)
-	}
+		if !hasString(row["uuid"]) { return fmt.Errorf("%s listener users[%d] requires uuid", proto, index) }
+		if proto == "vmess" && hasNonEmpty(row["flow"]) { return fmt.Errorf("vmess listener users[%d] does not support flow", index) }
+		if proto == "vless" && hasNonEmpty(row["alterId"]) { return fmt.Errorf("vless listener users[%d] does not support alterId", index) }
+	} else if !hasString(row["password"]) { return fmt.Errorf("%s listener users[%d] requires password", proto, index) }
 	return nil
 }
 
-func hasCertificatePair(cfg map[string]interface{}) bool {
-	return hasString(cfg["certificate"]) && (hasString(cfg["private-key"]) || hasString(cfg["private_key"]))
-}
-
-func hasString(value interface{}) bool {
-	s, ok := value.(string)
-	return ok && strings.TrimSpace(s) != ""
-}
-
+func hasCertificatePair(cfg map[string]interface{}) bool { return hasString(cfg["certificate"]) && (hasString(cfg["private-key"]) || hasString(cfg["private_key"])) }
+func hasString(value interface{}) bool { s, ok := value.(string); return ok && strings.TrimSpace(s) != "" }
 func hasNonEmpty(value interface{}) bool {
-	if value == nil {
-		return false
-	}
-	if s, ok := value.(string); ok {
-		return strings.TrimSpace(s) != ""
-	}
+	if value == nil { return false }
+	if s, ok := value.(string); ok { return strings.TrimSpace(s) != "" }
 	v := reflect.ValueOf(value)
-	switch v.Kind() {
-	case reflect.Slice, reflect.Map:
-		return v.Len() > 0
-	default:
-		return true
-	}
+	switch v.Kind() { case reflect.Slice, reflect.Map: return v.Len() > 0; default: return true }
 }
-
-func boolValue(v interface{}) bool {
-	b, _ := v.(bool)
-	return b
-}
-
-func numeric(v interface{}) (float64, bool) {
-	n, ok := v.(float64)
-	return n, ok
-}
+func boolValue(v interface{}) bool { b, _ := v.(bool); return b }
+func numeric(v interface{}) (float64, bool) { n, ok := v.(float64); return n, ok }

--- a/backend/internal/node/validator_test.go
+++ b/backend/internal/node/validator_test.go
@@ -1,71 +1,30 @@
 package node
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
 )
 
-func validNode(protocol, config string) *models.Listener {
-	return &models.Listener{Name: "test", Protocol: protocol, Type: protocol, Port: 443, BindAddress: "0.0.0.0", Enabled: true, Config: config}
-}
+func validNode(protocol, config string) *models.Listener { return &models.Listener{Name: "test", Protocol: protocol, Type: protocol, Port: 443, BindAddress: "0.0.0.0", Enabled: true, Config: config} }
 
-func TestValidateNodeRejectsUnknownField(t *testing.T) {
-	err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"not-a-mihomo-field":true}`))
-	if err == nil || !strings.Contains(err.Error(), "unsupported field") {
-		t.Fatalf("expected unsupported field error, got %v", err)
-	}
-}
+func TestValidateNodeRejectsUnknownField(t *testing.T) { err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"not-a-mihomo-field":true}`)); if err == nil || !strings.Contains(err.Error(), "unsupported field") { t.Fatalf("expected unsupported field error, got %v", err) } }
+func TestValidateNodeRejectsTLSCertificateMismatch(t *testing.T) { err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"certificate":"/tmp/server.crt"}`)); if err == nil || !strings.Contains(err.Error(), "certificate and private-key together") { t.Fatalf("expected certificate pair error, got %v", err) } }
+func TestValidateNodeRejectsRealityAndCertificateTogether(t *testing.T) { err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"certificate":"/tmp/server.crt","private-key":"/tmp/server.key","reality-config":{"dest":"example.com:443"}}`)); if err == nil || !strings.Contains(err.Error(), "mutually exclusive TLS modes") { t.Fatalf("expected TLS exclusivity error, got %v", err) } }
+func TestValidateNodeRejectsVmessFlow(t *testing.T) { err := ValidateNode(validNode("vmess", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001","flow":"xtls-rprx-vision"}]}`)); if err == nil || !strings.Contains(err.Error(), "vmess listener users[0] does not support flow") { t.Fatalf("expected VMess flow error, got %v", err) } }
+func TestValidateNodeRejectsVlessAlterID(t *testing.T) { err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001","alterId":0}]}`)); if err == nil || !strings.Contains(err.Error(), "vless listener users[0] does not support alterId") { t.Fatalf("expected VLESS alterId error, got %v", err) } }
+func TestValidateNodeRejectsTuicV4V5Mix(t *testing.T) { err := ValidateNode(validNode("tuic", `{"users":{"00000000-0000-0000-0000-000000000001":"password"},"token":["TOKEN"]}`)); if err == nil || !strings.Contains(err.Error(), "exactly one of users") { t.Fatalf("expected TUIC mode exclusivity error, got %v", err) } }
+func TestValidateNodeRejectsAnyTLSReality(t *testing.T) { err := ValidateNode(validNode("anytls", `{"users":{"u":"password"},"reality-config":{"dest":"example.com:443"}}`)); if err == nil || !strings.Contains(err.Error(), "unsupported field") { t.Fatalf("expected AnyTLS schema rejection, got %v", err) } }
+func TestValidateNodeAcceptsVlessReality(t *testing.T) { err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"reality-config":{"dest":"example.com:443","private-key":"key","short-id":["0123456789abcdef"],"server-names":["example.com"]}}`)); if err != nil { t.Fatalf("expected valid VLESS Reality config, got %v", err) } }
+func TestValidateNodeAcceptsTuicV5(t *testing.T) { err := ValidateNode(validNode("tuic", `{"users":{"00000000-0000-0000-0000-000000000001":"password"}}`)); if err != nil { t.Fatalf("expected valid TUIC V5 config, got %v", err) } }
 
-func TestValidateNodeRejectsTLSCertificateMismatch(t *testing.T) {
-	err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"certificate":"/tmp/server.crt"}`))
-	if err == nil || !strings.Contains(err.Error(), "certificate and private-key together") {
-		t.Fatalf("expected certificate pair error, got %v", err)
-	}
-}
-
-func TestValidateNodeRejectsRealityAndCertificateTogether(t *testing.T) {
-	err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"certificate":"/tmp/server.crt","private-key":"/tmp/server.key","reality-config":{"dest":"example.com:443"}}`))
-	if err == nil || !strings.Contains(err.Error(), "mutually exclusive TLS modes") {
-		t.Fatalf("expected TLS exclusivity error, got %v", err)
-	}
-}
-
-func TestValidateNodeRejectsVmessFlow(t *testing.T) {
-	err := ValidateNode(validNode("vmess", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001","flow":"xtls-rprx-vision"}]}`))
-	if err == nil || !strings.Contains(err.Error(), "vmess listener users[0] does not support flow") {
-		t.Fatalf("expected VMess flow error, got %v", err)
-	}
-}
-
-func TestValidateNodeRejectsVlessAlterID(t *testing.T) {
-	err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001","alterId":0}]}`))
-	if err == nil || !strings.Contains(err.Error(), "vless listener users[0] does not support alterId") {
-		t.Fatalf("expected VLESS alterId error, got %v", err)
-	}
-}
-
-func TestValidateNodeRejectsTuicV4V5Mix(t *testing.T) {
-	err := ValidateNode(validNode("tuic", `{"users":{"00000000-0000-0000-0000-000000000001":"password"},"token":["TOKEN"]}`))
-	if err == nil || !strings.Contains(err.Error(), "exactly one of users") {
-		t.Fatalf("expected TUIC mode exclusivity error, got %v", err)
-	}
-}
-
-func TestValidateNodeRejectsAnyTLSReality(t *testing.T) {
-	err := ValidateNode(validNode("anytls", `{"users":{"u":"password"},"reality-config":{"dest":"example.com:443"}}`))
-	if err == nil || !strings.Contains(err.Error(), "unsupported field") {
-		t.Fatalf("expected AnyTLS schema rejection, got %v", err)
-	}
-}
-
-func TestValidateNodeAcceptsVlessReality(t *testing.T) {
-	err := ValidateNode(validNode("vless", `{"users":[{"username":"u","uuid":"00000000-0000-0000-0000-000000000001"}],"reality-config":{"dest":"example.com:443","private-key":"key","short-id":["0123456789abcdef"],"server-names":["example.com"]}}`))
-	if err != nil { t.Fatalf("expected valid VLESS Reality config, got %v", err) }
-}
-
-func TestValidateNodeAcceptsTuicV5(t *testing.T) {
-	err := ValidateNode(validNode("tuic", `{"users":{"00000000-0000-0000-0000-000000000001":"password"}}`))
-	if err != nil { t.Fatalf("expected valid TUIC V5 config, got %v", err) }
+func TestValidateNodeGeneratesVlessClientCredentialWhenMissing(t *testing.T) {
+	listener := validNode("vless", `{}`)
+	if err := ValidateNode(listener); err != nil { t.Fatalf("expected empty VLESS config to be completed, got %v", err) }
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(listener.Config), &cfg); err != nil { t.Fatalf("generated config is invalid JSON: %v", err) }
+	users, ok := cfg["users"].([]interface{}); if !ok || len(users) != 1 { t.Fatalf("expected one generated VLESS user, got %#v", cfg["users"]) }
+	row, ok := users[0].(map[string]interface{}); if !ok || row["username"] == "" || row["uuid"] == "" { t.Fatalf("generated VLESS credential is incomplete: %#v", users[0]) }
 }

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -10,194 +10,84 @@ import (
 	"time"
 
 	"github.com/dzx941/3m-ui/backend/internal/database/models"
+	"github.com/dzx941/3m-ui/backend/internal/node"
 	"github.com/dzx941/3m-ui/backend/internal/security"
 	"gorm.io/gorm"
 )
 
 type Service struct { db *gorm.DB }
 var GlobalService *Service
-
 func InitService(db *gorm.DB) { GlobalService = &Service{db: db} }
 
-type CreateInput struct {
-	Username string `json:"username" binding:"required"`
-	Password string `json:"password"`
-	UUID string `json:"uuid"`
-	TrafficLimit int64 `json:"traffic_limit"`
-	ExpireTime *time.Time `json:"expire_time"`
-	Enabled *bool `json:"enabled"`
-}
-
-type UpdateInput struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	UUID string `json:"uuid"`
-	TrafficLimit *int64 `json:"traffic_limit"`
-	ExpireTime *time.Time `json:"expire_time"`
-	Enabled *bool `json:"enabled"`
-}
-
+type CreateInput struct { Username string `json:"username" binding:"required"`; Password string `json:"password"`; UUID string `json:"uuid"`; TrafficLimit int64 `json:"traffic_limit"`; ExpireTime *time.Time `json:"expire_time"`; Enabled *bool `json:"enabled"` }
+type UpdateInput struct { Username string `json:"username"`; Password string `json:"password"`; UUID string `json:"uuid"`; TrafficLimit *int64 `json:"traffic_limit"`; ExpireTime *time.Time `json:"expire_time"`; Enabled *bool `json:"enabled"` }
 type Credential struct { Username, Password, UUID string }
 
 func (s *Service) Create(in CreateInput) (*models.ProxyUser, error) {
-	username := strings.TrimSpace(in.Username)
-	if username == "" { return nil, errors.New("username is required") }
-	password := in.Password
-	if password == "" { password, _ = randomToken(24) }
-	uuid := in.UUID
-	if uuid == "" { var err error; uuid, err = newUUID(); if err != nil { return nil, err } }
-	expire := time.Time{}
-	if in.ExpireTime != nil { expire = in.ExpireTime.UTC() }
-	enabled := true
-	if in.Enabled != nil { enabled = *in.Enabled }
-	encrypted, err := encryptPassword(password)
-	if err != nil { return nil, err }
+	username := strings.TrimSpace(in.Username); if username == "" { return nil, errors.New("username is required") }
+	password := in.Password; if password == "" { password, _ = randomToken(24) }
+	uuid := in.UUID; if uuid == "" { var err error; uuid, err = newUUID(); if err != nil { return nil, err } }
+	expire := time.Time{}; if in.ExpireTime != nil { expire = in.ExpireTime.UTC() }
+	enabled := true; if in.Enabled != nil { enabled = *in.Enabled }
+	encrypted, err := encryptPassword(password); if err != nil { return nil, err }
 	u := &models.ProxyUser{Username: username, PasswordEncrypted: encrypted, UUID: uuid, TrafficLimit: in.TrafficLimit, ExpireTime: expire, Enabled: enabled}
-	if err := s.db.Create(u).Error; err != nil { return nil, fmt.Errorf("create proxy user: %w", err) }
-	return u, nil
+	if err := s.db.Create(u).Error; err != nil { return nil, fmt.Errorf("create proxy user: %w", err) }; return u, nil
 }
+func (s *Service) GetAll() ([]models.ProxyUser, error) { var users []models.ProxyUser; if err := s.db.Order("id desc").Find(&users).Error; err != nil { return nil, err }; return users, nil }
+func (s *Service) GetByID(id uint) (*models.ProxyUser, error) { var u models.ProxyUser; if err := s.db.First(&u, id).Error; err != nil { return nil, err }; return &u, nil }
+func (s *Service) Update(id uint, in UpdateInput) (*models.ProxyUser, error) { u, err := s.GetByID(id); if err != nil { return nil, err }; if strings.TrimSpace(in.Username) != "" { u.Username = strings.TrimSpace(in.Username) }; if in.Password != "" { u.PasswordEncrypted, err = encryptPassword(in.Password); if err != nil { return nil, err } }; if in.UUID != "" { u.UUID = in.UUID }; if in.TrafficLimit != nil { u.TrafficLimit = *in.TrafficLimit }; if in.ExpireTime != nil { u.ExpireTime = in.ExpireTime.UTC() }; if in.Enabled != nil { u.Enabled = *in.Enabled }; if err := s.db.Save(u).Error; err != nil { return nil, fmt.Errorf("update proxy user: %w", err) }; return u, nil }
+func (s *Service) Delete(id uint) error { return s.db.Transaction(func(tx *gorm.DB) error { if err := tx.Where("proxy_user_id = ?", id).Delete(&models.ListenerUser{}).Error; err != nil { return err }; return tx.Delete(&models.ProxyUser{}, id).Error }) }
+func (s *Service) BindListeners(userID uint, listenerIDs []uint) error { return s.db.Transaction(func(tx *gorm.DB) error { var user models.ProxyUser; if err := tx.First(&user, userID).Error; err != nil { return err }; desired := make([]uint, 0, len(listenerIDs)); seen := map[uint]struct{}{}; for _, id := range listenerIDs { if _, ok := seen[id]; ok { continue }; seen[id] = struct{}{}; desired = append(desired, id) }; if len(desired) > 0 { var count int64; if err := tx.Model(&models.Listener{}).Where("id IN ?", desired).Count(&count).Error; err != nil { return err }; if count != int64(len(desired)) { return errors.New("one or more listener ids do not exist") }; if err := tx.Where("proxy_user_id = ? AND listener_id NOT IN ?", userID, desired).Delete(&models.ListenerUser{}).Error; err != nil { return err } } else if err := tx.Where("proxy_user_id = ?", userID).Delete(&models.ListenerUser{}).Error; err != nil { return err }; for _, listenerID := range desired { var binding models.ListenerUser; result := tx.Unscoped().Where("listener_id = ? AND proxy_user_id = ?", listenerID, userID).Find(&binding); if result.Error != nil { return result.Error }; if result.RowsAffected > 0 { if binding.DeletedAt.Valid { if err := tx.Unscoped().Model(&binding).Update("deleted_at", nil).Error; err != nil { return err } }; continue }; if err := tx.Create(&models.ListenerUser{ListenerID: listenerID, ProxyUserID: userID}).Error; err != nil { return err } }; return nil }) }
+func (s *Service) GetListeners(userID uint) ([]models.Listener, error) { var listeners []models.Listener; err := s.db.Model(&models.Listener{}).Joins("JOIN listener_users ON listener_users.listener_id = listeners.id AND listener_users.deleted_at IS NULL").Where("listener_users.proxy_user_id = ?", userID).Order("listeners.id").Find(&listeners).Error; return listeners, err }
+func IsCredentialActive(u models.ProxyUser) bool { now := time.Now(); if !u.Enabled { return false }; if !u.ExpireTime.IsZero() && !u.ExpireTime.After(now) { return false }; if u.TrafficLimit > 0 && u.TrafficUsed >= u.TrafficLimit { return false }; return true }
 
-func (s *Service) GetAll() ([]models.ProxyUser, error) {
-	var users []models.ProxyUser
-	if err := s.db.Order("id desc").Find(&users).Error; err != nil { return nil, err }
-	return users, nil
-}
-
-func (s *Service) GetByID(id uint) (*models.ProxyUser, error) {
-	var u models.ProxyUser
-	if err := s.db.First(&u, id).Error; err != nil { return nil, err }
-	return &u, nil
-}
-
-func (s *Service) Update(id uint, in UpdateInput) (*models.ProxyUser, error) {
-	u, err := s.GetByID(id)
-	if err != nil { return nil, err }
-	if strings.TrimSpace(in.Username) != "" { u.Username = strings.TrimSpace(in.Username) }
-	if in.Password != "" { u.PasswordEncrypted, err = encryptPassword(in.Password); if err != nil { return nil, err } }
-	if in.UUID != "" { u.UUID = in.UUID }
-	if in.TrafficLimit != nil { u.TrafficLimit = *in.TrafficLimit }
-	if in.ExpireTime != nil { u.ExpireTime = in.ExpireTime.UTC() }
-	if in.Enabled != nil { u.Enabled = *in.Enabled }
-	if err := s.db.Save(u).Error; err != nil { return nil, fmt.Errorf("update proxy user: %w", err) }
-	return u, nil
-}
-
-func (s *Service) Delete(id uint) error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("proxy_user_id = ?", id).Delete(&models.ListenerUser{}).Error; err != nil { return err }
-		return tx.Delete(&models.ProxyUser{}, id).Error
-	})
-}
-
-func (s *Service) BindListeners(userID uint, listenerIDs []uint) error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
-		var user models.ProxyUser
-		if err := tx.First(&user, userID).Error; err != nil { return err }
-		desired := make([]uint, 0, len(listenerIDs))
-		seen := map[uint]struct{}{}
-		for _, id := range listenerIDs { if _, ok := seen[id]; ok { continue }; seen[id] = struct{}{}; desired = append(desired, id) }
-		if len(desired) > 0 {
-			var count int64
-			if err := tx.Model(&models.Listener{}).Where("id IN ?", desired).Count(&count).Error; err != nil { return err }
-			if count != int64(len(desired)) { return errors.New("one or more listener ids do not exist") }
-			if err := tx.Where("proxy_user_id = ? AND listener_id NOT IN ?", userID, desired).Delete(&models.ListenerUser{}).Error; err != nil { return err }
-		} else if err := tx.Where("proxy_user_id = ?", userID).Delete(&models.ListenerUser{}).Error; err != nil { return err }
-		for _, listenerID := range desired {
-			var binding models.ListenerUser
-			result := tx.Unscoped().Where("listener_id = ? AND proxy_user_id = ?", listenerID, userID).Find(&binding)
-			if result.Error != nil { return result.Error }
-			if result.RowsAffected > 0 {
-				if binding.DeletedAt.Valid { if err := tx.Unscoped().Model(&binding).Update("deleted_at", nil).Error; err != nil { return err } }
-				continue
-			}
-			if err := tx.Create(&models.ListenerUser{ListenerID: listenerID, ProxyUserID: userID}).Error; err != nil { return err }
-		}
-		return nil
-	})
-}
-
-func (s *Service) GetListeners(userID uint) ([]models.Listener, error) {
-	var listeners []models.Listener
-	err := s.db.Model(&models.Listener{}).Joins("JOIN listener_users ON listener_users.listener_id = listeners.id AND listener_users.deleted_at IS NULL").Where("listener_users.proxy_user_id = ?", userID).Order("listeners.id").Find(&listeners).Error
-	return listeners, err
-}
-
-func IsCredentialActive(u models.ProxyUser) bool {
-	now := time.Now()
-	if !u.Enabled { return false }
-	if !u.ExpireTime.IsZero() && !u.ExpireTime.After(now) { return false }
-	if u.TrafficLimit > 0 && u.TrafficUsed >= u.TrafficLimit { return false }
-	return true
-}
-
-// ActiveCredentialsByListener uses credentials embedded in the unified Node
-// listener configuration as the primary source. Legacy ProxyUser bindings are
-// retained only as a backward-compatible fallback for old databases.
+// ActiveCredentialsByListener reads credentials from the unified node config.
+// For old databases, ValidateNode also backfills a stable generated credential
+// before the export path is evaluated, so subscriptions no longer depend on
+// Proxy User management.
 func (s *Service) ActiveCredentialsByListener() (map[uint][]Credential, error) {
 	result := make(map[uint][]Credential)
 	var listeners []models.Listener
 	if err := s.db.Where("enabled = ?", true).Find(&listeners).Error; err != nil { return nil, err }
 	for _, listener := range listeners {
+		before := listener.Config
+		if err := node.ValidateNode(&listener); err != nil { return nil, fmt.Errorf("validate listener %q: %w", listener.Name, err) }
+		if listener.Config != before {
+			if err := s.db.Model(&models.Listener{}).Where("id = ?", listener.ID).Update("config", listener.Config).Error; err != nil { return nil, fmt.Errorf("save generated credentials for listener %q: %w", listener.Name, err) }
+		}
 		creds := credentialsFromListenerConfig(listener.Protocol, listener.Config)
 		if len(creds) > 0 { result[listener.ID] = creds }
 	}
 
+	// Legacy fallback remains only for databases that already have ProxyUser
+	// bindings and whose listener protocol has no embedded credential format.
 	var rows []struct { ListenerID uint; ProxyUserID uint }
 	if err := s.db.Model(&models.ListenerUser{}).Select("listener_id, proxy_user_id").Where("deleted_at IS NULL").Find(&rows).Error; err != nil { return nil, err }
 	for _, row := range rows {
 		if len(result[row.ListenerID]) > 0 { continue }
-		u, err := s.GetByID(row.ProxyUserID)
-		if err != nil { if errors.Is(err, gorm.ErrRecordNotFound) { continue }; return nil, err }
+		u, err := s.GetByID(row.ProxyUserID); if err != nil { if errors.Is(err, gorm.ErrRecordNotFound) { continue }; return nil, err }
 		if !IsCredentialActive(*u) { continue }
-		password, err := decryptPassword(u.PasswordEncrypted)
-		if err != nil { return nil, fmt.Errorf("decrypt proxy user %d password: %w", u.ID, err) }
+		password, err := decryptPassword(u.PasswordEncrypted); if err != nil { return nil, fmt.Errorf("decrypt proxy user %d password: %w", u.ID, err) }
 		result[row.ListenerID] = append(result[row.ListenerID], Credential{Username: u.Username, Password: password, UUID: u.UUID})
 	}
 	return result, nil
 }
 
 func credentialsFromListenerConfig(protocol, raw string) []Credential {
-	var cfg map[string]interface{}
-	if strings.TrimSpace(raw) == "" || json.Unmarshal([]byte(raw), &cfg) != nil { return nil }
-	users, ok := cfg["users"]
-	if !ok { return nil }
-	result := []Credential{}
+	var cfg map[string]interface{}; if strings.TrimSpace(raw) == "" || json.Unmarshal([]byte(raw), &cfg) != nil { return nil }
+	users, ok := cfg["users"]; if !ok { return nil }; result := []Credential{}
 	switch protocol {
 	case "anytls", "hysteria2", "mieru", "tuic":
-		if m, ok := users.(map[string]interface{}); ok {
-			for username, value := range m { result = append(result, Credential{Username: username, Password: fmt.Sprint(value), UUID: username}) }
-		}
+		if m, ok := users.(map[string]interface{}); ok { for username, value := range m { result = append(result, Credential{Username: username, Password: fmt.Sprint(value), UUID: username}) } }
 	default:
-		if list, ok := users.([]interface{}); ok {
-			for _, value := range list {
-				row, ok := value.(map[string]interface{}); if !ok { continue }
-				result = append(result, Credential{Username: fmt.Sprint(row["username"]), Password: fmt.Sprint(row["password"]), UUID: fmt.Sprint(row["uuid"])})
-			}
-		}
+		if list, ok := users.([]interface{}); ok { for _, value := range list { row, ok := value.(map[string]interface{}); if !ok { continue }; result = append(result, Credential{Username: fmt.Sprint(row["username"]), Password: fmt.Sprint(row["password"]), UUID: fmt.Sprint(row["uuid"])}) } }
 	}
 	return result
 }
-
 func safeMask(s string) string { if len(s) <= 8 { return "********" }; return s[:4] + "..." + s[len(s)-4:] }
-
-type SafeUser struct {
-	ID uint `json:"id"`; Username string `json:"username"`; UUIDMasked string `json:"uuid_masked"`; TrafficLimit int64 `json:"traffic_limit"`; TrafficUsed int64 `json:"traffic_used"`; UploadBytes int64 `json:"upload_bytes"`; DownloadBytes int64 `json:"download_bytes"`; LastSeen *time.Time `json:"last_seen"`; Online bool `json:"online"`; ExpireTime time.Time `json:"expire_time"`; Enabled bool `json:"enabled"`; Blocked bool `json:"blocked"`
-}
-
-func ToSafeUser(u *models.ProxyUser) SafeUser {
-	return SafeUser{ID: u.ID, Username: u.Username, UUIDMasked: safeMask(u.UUID), TrafficLimit: u.TrafficLimit, TrafficUsed: u.TrafficUsed, UploadBytes: u.UploadBytes, DownloadBytes: u.DownloadBytes, LastSeen: u.LastSeen, Online: u.Online, ExpireTime: u.ExpireTime, Enabled: u.Enabled, Blocked: !IsCredentialActive(*u)}
-}
-
+type SafeUser struct { ID uint `json:"id"`; Username string `json:"username"`; UUIDMasked string `json:"uuid_masked"`; TrafficLimit int64 `json:"traffic_limit"`; TrafficUsed int64 `json:"traffic_used"`; UploadBytes int64 `json:"upload_bytes"`; DownloadBytes int64 `json:"download_bytes"`; LastSeen *time.Time `json:"last_seen"`; Online bool `json:"online"`; ExpireTime time.Time `json:"expire_time"`; Enabled bool `json:"enabled"`; Blocked bool `json:"blocked"` }
+func ToSafeUser(u *models.ProxyUser) SafeUser { return SafeUser{ID: u.ID, Username: u.Username, UUIDMasked: safeMask(u.UUID), TrafficLimit: u.TrafficLimit, TrafficUsed: u.TrafficUsed, UploadBytes: u.UploadBytes, DownloadBytes: u.DownloadBytes, LastSeen: u.LastSeen, Online: u.Online, ExpireTime: u.ExpireTime, Enabled: u.Enabled, Blocked: !IsCredentialActive(*u)} }
 func encryptPassword(plain string) (string, error) { return security.Encrypt(plain) }
 func decryptPassword(encoded string) (string, error) { return security.Decrypt(encoded) }
-
-func newUUID() (string, error) {
-	b := make([]byte, 16); if _, err := rand.Read(b); err != nil { return "", err }
-	b[6] = (b[6] & 0x0f) | 0x40; b[8] = (b[8] & 0x3f) | 0x80
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
-}
-
-func randomToken(n int) (string, error) {
-	b := make([]byte, n); if _, err := rand.Read(b); err != nil { return "", err }
-	return base64.RawURLEncoding.EncodeToString(b), nil
-}
+func newUUID() (string, error) { b := make([]byte, 16); if _, err := rand.Read(b); err != nil { return "", err }; b[6] = (b[6] & 0x0f) | 0x40; b[8] = (b[8] & 0x3f) | 0x80; return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil }
+func randomToken(n int) (string, error) { b := make([]byte, n); if _, err := rand.Read(b); err != nil { return "", err }; return base64.RawURLEncoding.EncodeToString(b), nil }

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -7,10 +7,43 @@ interface I18nContextProps {
   t: (key: string) => string;
 }
 
+const fallbackMessages: Record<Locale, Record<string, string>> = {
+  'zh-CN': {
+    'nodes.protocol': '协议',
+    'nodes.listen': '监听地址',
+    'nodes.status': '状态',
+    'nodes.actions': '操作',
+    'nodes.rule': '入站规则',
+    'nodes.rulePlaceholder': '可选规则',
+    'nodes.proxy': '代理',
+    'nodes.proxyPlaceholder': '可选上游代理',
+    'nodes.protocolHint': '节点由 Mihomo Listener 配置驱动，保存后会自动生成客户端代理配置。',
+    'nodes.clientConfigHint': '以下链接由当前节点自动生成，可直接提供给对应客户端。',
+    'nodes.mihomoClash': 'Mihomo / Clash',
+    'nodes.singbox': 'sing-box',
+    'nodes.shadowrocket': 'Shadowrocket',
+  },
+  'en-US': {
+    'nodes.protocol': 'Protocol',
+    'nodes.listen': 'Listen Address',
+    'nodes.status': 'Status',
+    'nodes.actions': 'Actions',
+    'nodes.rule': 'Inbound Rule',
+    'nodes.rulePlaceholder': 'Optional rule',
+    'nodes.proxy': 'Proxy',
+    'nodes.proxyPlaceholder': 'Optional upstream proxy',
+    'nodes.protocolHint': 'Nodes are driven by Mihomo Listener configuration and automatically generate client proxy configurations after saving.',
+    'nodes.clientConfigHint': 'These links are generated from the current node and can be provided directly to the corresponding client.',
+    'nodes.mihomoClash': 'Mihomo / Clash',
+    'nodes.singbox': 'sing-box',
+    'nodes.shadowrocket': 'Shadowrocket',
+  },
+};
+
 const I18nContext = createContext<I18nContextProps>({
   locale: 'zh-CN',
   setLocale: () => {},
-  t: (key: string) => messages['zh-CN'][key] || key,
+  t: (key: string) => messages['zh-CN'][key] || fallbackMessages['zh-CN'][key] || key,
 });
 
 export const I18nProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
@@ -24,7 +57,7 @@ export const I18nProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     localStorage.setItem('3m-ui.locale', l);
   };
 
-  const t = (key: string) => messages[locale][key] || messages['zh-CN'][key] || key;
+  const t = (key: string) => messages[locale][key] || fallbackMessages[locale][key] || messages['zh-CN'][key] || fallbackMessages['zh-CN'][key] || key;
 
   return <I18nContext.Provider value={{ locale, setLocale, t }}>{children}</I18nContext.Provider>;
 };

--- a/frontend/src/pages/Listeners.tsx
+++ b/frontend/src/pages/Listeners.tsx
@@ -8,34 +8,9 @@ import { useI18n } from '../i18n';
 
 const { Title, Paragraph, Text } = Typography;
 
-type NodeRecord = {
-  ID: number;
-  name: string;
-  protocol: ListenerProtocol;
-  port: number;
-  bind_address: string;
-  listen?: string;
-  rule?: string;
-  proxy?: string;
-  enabled: boolean;
-  config: string;
-  status: string;
-};
-
-type ClientAccess = {
-  name: string;
-  mihomo_link: string;
-  clash_link: string;
-  singbox_link: string;
-  shadowrocket_link: string;
-};
-
-const protocolLabels: Record<ListenerProtocol, string> = {
-  shadowsocks: 'Shadowsocks', snell: 'Snell', vmess: 'VMess', vless: 'VLESS', trojan: 'Trojan',
-  hysteria2: 'Hysteria 2', tuic: 'TUIC V4/V5', shadowquic: 'ShadowQUIC', anytls: 'AnyTLS',
-  mieru: 'Mieru', sudoku: 'Sudoku', trusttunnel: 'TrustTunnel',
-};
-
+type NodeRecord = { ID: number; name: string; protocol: ListenerProtocol; port: number; bind_address: string; listen?: string; rule?: string; proxy?: string; enabled: boolean; config: string; status: string };
+type ClientAccess = { name: string; mihomo_link: string; clash_link: string; singbox_link: string; shadowrocket_link: string };
+const protocolLabels: Record<ListenerProtocol, string> = { shadowsocks: 'Shadowsocks', snell: 'Snell', vmess: 'VMess', vless: 'VLESS', trojan: 'Trojan', hysteria2: 'Hysteria 2', tuic: 'TUIC V4/V5', shadowquic: 'ShadowQUIC', anytls: 'AnyTLS', mieru: 'Mieru', sudoku: 'Sudoku', trusttunnel: 'TrustTunnel' };
 const mapUserProtocols = new Set<ListenerProtocol>(['anytls', 'hysteria2', 'mieru', 'tuic']);
 
 const prune = (value: unknown): unknown => {
@@ -64,196 +39,69 @@ const serializeProtocolConfig = (protocol: ListenerProtocol, raw: Record<string,
       const password = String(row.password ?? '').trim();
       if (username && password) users[username] = password;
     }
-    if (Object.keys(users).length) cfg.users = users;
-    else delete cfg.users;
+    if (Object.keys(users).length) cfg.users = users; else delete cfg.users;
   }
   return cfg;
 };
-
 const hydrateProtocolConfig = (protocol: ListenerProtocol, raw: Record<string, unknown>) => {
   const cfg = JSON.parse(JSON.stringify(raw || {})) as Record<string, unknown>;
-  if (mapUserProtocols.has(protocol) && cfg.users && typeof cfg.users === 'object' && !Array.isArray(cfg.users)) {
-    cfg.users = Object.entries(cfg.users as Record<string, unknown>).map(([username, password]) => ({ username, password }));
-  }
+  if (mapUserProtocols.has(protocol) && cfg.users && typeof cfg.users === 'object' && !Array.isArray(cfg.users)) cfg.users = Object.entries(cfg.users as Record<string, unknown>).map(([username, password]) => ({ username, password }));
   return cfg;
 };
 
 const NodesPage: React.FC = () => {
-  const { t } = useI18n();
-  const [rows, setRows] = useState<NodeRecord[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [open, setOpen] = useState(false);
-  const [editing, setEditing] = useState<NodeRecord | null>(null);
-  const [access, setAccess] = useState<ClientAccess | null>(null);
-  const [accessOpen, setAccessOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [form] = Form.useForm();
+  const { t, locale } = useI18n();
+  const [rows, setRows] = useState<NodeRecord[]>([]); const [loading, setLoading] = useState(false); const [open, setOpen] = useState(false); const [editing, setEditing] = useState<NodeRecord | null>(null); const [access, setAccess] = useState<ClientAccess | null>(null); const [accessOpen, setAccessOpen] = useState(false); const [saving, setSaving] = useState(false); const [form] = Form.useForm();
   const protocol = Form.useWatch('protocol', form) as ListenerProtocol | undefined;
 
-  const load = async () => {
-    setLoading(true);
-    try {
-      setRows((await apiRequest<NodeRecord[]>('/nodes')) || []);
-    } catch (error: unknown) {
-      message.error(error instanceof Error ? error.message : t('nodes.loadFailed'));
-    } finally {
-      setLoading(false);
-    }
-  };
-
+  const load = async () => { setLoading(true); try { setRows((await apiRequest<NodeRecord[]>('/nodes')) || []); } catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.loadFailed')); } finally { setLoading(false); } };
   useEffect(() => { void load(); }, []);
-
-  const openCreate = () => {
-    setEditing(null);
-    form.resetFields();
-    form.setFieldsValue({ bind_address: '0.0.0.0', port: 443, protocol: 'vless', enabled: true, protocolConfig: {} });
-    setOpen(true);
-  };
-
-  const openEdit = (row: NodeRecord) => {
-    let config: Record<string, unknown> = {};
-    try { config = hydrateProtocolConfig(row.protocol, JSON.parse(row.config || '{}')); }
-    catch { message.error(t('nodes.invalidConfig')); return; }
-    setEditing(row);
-    form.resetFields();
-    form.setFieldsValue({ ...row, bind_address: row.bind_address || row.listen || '0.0.0.0', protocolConfig: config });
-    setOpen(true);
-  };
-
-  const generateClientAccess = async (id: number) => {
-    try {
-      const data = await apiRequest<ClientAccess>(`/nodes/${id}/client-access`, { method: 'POST' });
-      setAccess(data);
-      setAccessOpen(true);
-    } catch (error: unknown) {
-      message.error(error instanceof Error ? error.message : t('nodes.clientUnavailable'));
-    }
-  };
+  const openCreate = () => { setEditing(null); form.resetFields(); form.setFieldsValue({ bind_address: '0.0.0.0', port: 443, protocol: 'vless', enabled: true, protocolConfig: {} }); setOpen(true); };
+  const openEdit = (row: NodeRecord) => { let config: Record<string, unknown> = {}; try { config = hydrateProtocolConfig(row.protocol, JSON.parse(row.config || '{}')); } catch { message.error(t('nodes.invalidConfig')); return; } setEditing(row); form.resetFields(); form.setFieldsValue({ ...row, bind_address: row.bind_address || row.listen || '0.0.0.0', protocolConfig: config }); setOpen(true); };
+  const generateClientAccess = async (id: number) => { try { const data = await apiRequest<ClientAccess>(`/nodes/${id}/client-access`, { method: 'POST' }); setAccess(data); setAccessOpen(true); } catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.clientUnavailable')); } };
 
   const save = async () => {
-    if (saving) return;
-    setSaving(true);
+    if (saving) return; setSaving(true);
     try {
-      const values = await form.validateFields();
-      const selected = values.protocol as ListenerProtocol;
-      const payload = {
-        name: String(values.name || '').trim(),
-        protocol: selected,
-        type: selected,
-        port: Number(values.port),
-        bind_address: String(values.bind_address || '0.0.0.0').trim(),
-        listen: String(values.bind_address || '0.0.0.0').trim(),
-        rule: values.rule || '',
-        proxy: values.proxy || '',
-        enabled: Boolean(values.enabled),
-        status: values.enabled ? 'active' : 'inactive',
-        config: JSON.stringify(serializeProtocolConfig(selected, values.protocolConfig || {})),
-      };
-      const id = editing?.ID;
-      const result = await apiRequest<NodeRecord>(id ? `/nodes/${id}` : '/nodes', {
-        method: id ? 'PUT' : 'POST',
-        body: JSON.stringify(payload),
-      });
-      setOpen(false);
-      await load();
-      message.success(id ? t('nodes.updated') : t('nodes.created'));
-      if (!id && result?.ID) await generateClientAccess(result.ID);
+      const values = await form.validateFields(); const selected = values.protocol as ListenerProtocol;
+      const payload = { name: String(values.name || '').trim(), protocol: selected, type: selected, port: Number(values.port), bind_address: String(values.bind_address || '0.0.0.0').trim(), listen: String(values.bind_address || '0.0.0.0').trim(), rule: values.rule || '', proxy: values.proxy || '', enabled: Boolean(values.enabled), status: values.enabled ? 'active' : 'inactive', config: JSON.stringify(serializeProtocolConfig(selected, values.protocolConfig || {})) };
+      const id = editing?.ID; const result = await apiRequest<NodeRecord>(id ? `/nodes/${id}` : '/nodes', { method: id ? 'PUT' : 'POST', body: JSON.stringify(payload) });
+      setOpen(false); await load(); message.success(id ? t('nodes.updated') : t('nodes.created')); if (!id && result?.ID) await generateClientAccess(result.ID);
     } catch (error: unknown) {
-      if (error && typeof error === 'object' && 'errorFields' in error) {
-        const first = (error as { errorFields?: Array<{ name?: Array<string | number>; errors?: string[] }> }).errorFields?.[0];
-        const field = first?.name?.join('.') || '';
-        const detail = first?.errors?.[0] || t('nodes.invalidConfig');
-        message.error(field ? `${field}: ${detail}` : detail);
-        if (first?.name) form.scrollToField(first.name);
-      } else if (error instanceof Error) {
-        message.error(error.message);
-      } else if (error && typeof error === 'object' && 'message' in error) {
-        message.error(String((error as { message: unknown }).message));
-      } else {
-        message.error(t('nodes.saveFailed'));
-      }
-    } finally {
-      setSaving(false);
-    }
+      if (error && typeof error === 'object' && 'errorFields' in error) { const first = (error as { errorFields?: Array<{ name?: Array<string | number>; errors?: string[] }> }).errorFields?.[0]; const field = first?.name?.join('.') || ''; const detail = first?.errors?.[0] || t('nodes.invalidConfig'); message.error(field ? `${field}: ${detail}` : detail); if (first?.name) form.scrollToField(first.name); }
+      else if (error instanceof Error) message.error(error.message); else if (error && typeof error === 'object' && 'message' in error) message.error(String((error as { message: unknown }).message)); else message.error(t('nodes.saveFailed'));
+    } finally { setSaving(false); }
   };
+  const remove = async (id: number) => { try { await apiRequest(`/nodes/${id}`, { method: 'DELETE' }); await load(); message.success(t('nodes.deleted')); } catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.deleteFailed')); } };
+  const toggle = async (row: NodeRecord, enabled: boolean) => { try { await apiRequest(`/nodes/${row.ID}`, { method: 'PUT', body: JSON.stringify({ ...row, enabled, status: enabled ? 'active' : 'inactive' }) }); await load(); } catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.updatedFailed')); } };
+  const reload = async (id: number) => { try { await apiRequest(`/nodes/${id}/reload`, { method: 'POST' }); message.success(t('nodes.reloaded')); } catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.reloadFailed')); } };
+  const copy = async (value: string) => { try { await navigator.clipboard.writeText(value); message.success(t('nodes.linkCopied')); } catch { message.error(t('nodes.copyFailed')); } };
 
-  const remove = async (id: number) => {
-    try { await apiRequest(`/nodes/${id}`, { method: 'DELETE' }); await load(); message.success(t('nodes.deleted')); }
-    catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.deleteFailed')); }
-  };
-
-  const toggle = async (row: NodeRecord, enabled: boolean) => {
-    try {
-      await apiRequest(`/nodes/${row.ID}`, { method: 'PUT', body: JSON.stringify({ ...row, enabled, status: enabled ? 'active' : 'inactive' }) });
-      await load();
-    } catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.updatedFailed')); }
-  };
-
-  const reload = async (id: number) => {
-    try { await apiRequest(`/nodes/${id}/reload`, { method: 'POST' }); message.success(t('nodes.reloaded')); }
-    catch (error: unknown) { message.error(error instanceof Error ? error.message : t('nodes.reloadFailed')); }
-  };
-
-  const copy = async (value: string) => {
-    try { await navigator.clipboard.writeText(value); message.success(t('nodes.linkCopied')); }
-    catch { message.error(t('nodes.copyFailed')); }
-  };
+  const title = locale === 'zh-CN' ? '节点' : 'Nodes';
+  const subtitle = locale === 'zh-CN' ? '一个节点就是一个 Mihomo 入站配置，并自动生成对应的客户端代理配置。' : 'Each node is a Mihomo inbound configuration that automatically generates the corresponding client proxy configuration.';
+  const listenerLabel = locale === 'zh-CN' ? '监听协议' : 'Listener Protocol';
+  const clientHint = locale === 'zh-CN' ? '以下链接由当前节点自动生成，可直接提供给对应客户端。' : 'These links are generated from the current node and can be provided directly to the corresponding client.';
 
   const columns = [
     { title: t('nodes.name'), dataIndex: 'name', key: 'name' },
     { title: t('nodes.protocol'), dataIndex: 'protocol', key: 'protocol', render: (value: ListenerProtocol) => <Tag color="blue">{protocolLabels[value]}</Tag> },
     { title: t('nodes.listen'), key: 'listen', render: (_: unknown, row: NodeRecord) => `${row.bind_address || row.listen || '0.0.0.0'}:${row.port}` },
     { title: t('nodes.status'), dataIndex: 'enabled', key: 'enabled', render: (enabled: boolean, row: NodeRecord) => <Switch checked={enabled} onChange={(checked) => void toggle(row, checked)} /> },
-    { title: t('nodes.actions'), key: 'actions', render: (_: unknown, row: NodeRecord) => (
-      <Space>
-        <Button type="text" icon={<CopyOutlined />} title={t('nodes.clientConfig')} onClick={() => void generateClientAccess(row.ID)} />
-        <Button type="text" icon={<ReloadOutlined />} title={t('nodes.reload')} onClick={() => void reload(row.ID)} />
-        <Button type="text" icon={<EditOutlined />} title={t('nodes.edit')} onClick={() => openEdit(row)} />
-        <Popconfirm title={t('nodes.deleteConfirm')} onConfirm={() => void remove(row.ID)} okText={t('nodes.yes')} cancelText={t('nodes.no')}><Button type="text" danger icon={<DeleteOutlined />} /></Popconfirm>
-      </Space>
-    ) },
+    { title: t('nodes.actions'), key: 'actions', render: (_: unknown, row: NodeRecord) => <Space><Button type="text" icon={<CopyOutlined />} title={t('nodes.clientConfig')} onClick={() => void generateClientAccess(row.ID)} /><Button type="text" icon={<ReloadOutlined />} title={t('nodes.reload')} onClick={() => void reload(row.ID)} /><Button type="text" icon={<EditOutlined />} title={t('nodes.edit')} onClick={() => openEdit(row)} /><Popconfirm title={t('nodes.deleteConfirm')} onConfirm={() => void remove(row.ID)} okText={t('nodes.yes')} cancelText={t('nodes.no')}><Button type="text" danger icon={<DeleteOutlined />} /></Popconfirm></Space> },
   ];
 
-  return (
-    <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-        <div><Title level={2} style={{ margin: 0 }}>{t('nodes.title')}</Title><Paragraph style={{ margin: 0 }}>{t('nodes.subtitle')}</Paragraph></div>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>{t('nodes.create')}</Button>
-      </div>
-      <Table rowKey="ID" loading={loading} dataSource={rows} columns={columns} scroll={{ x: 'max-content' }} />
-
-      <Modal title={editing ? t('nodes.editTitle') : t('nodes.createTitle')} open={open} onOk={() => void save()} onCancel={() => setOpen(false)} confirmLoading={saving} destroyOnClose width={820}>
-        <Form form={form} layout="vertical">
-          <Form.Item name="name" label={t('nodes.name')} rules={[{ required: true, message: t('nodes.nameRequired') }]}><Input /></Form.Item>
-          <Space style={{ display: 'flex' }} align="start">
-            <Form.Item name="protocol" label={t('nodes.listenerProtocol')} rules={[{ required: true }]} style={{ width: 280 }}>
-              <Select options={LISTENER_PROTOCOLS.map((value) => ({ value, label: protocolLabels[value] }))} onChange={() => form.setFieldValue('protocolConfig', {})} />
-            </Form.Item>
-            <Form.Item name="port" label={t('nodes.port')} rules={[{ required: true }]} style={{ width: 180 }}><InputNumber min={1} max={65535} style={{ width: '100%' }} /></Form.Item>
-            <Form.Item name="bind_address" label={t('nodes.listenAddress')} rules={[{ required: true }]} style={{ width: 220 }}><Input placeholder="0.0.0.0" /></Form.Item>
-          </Space>
-          <Space style={{ display: 'flex' }} align="start">
-            <Form.Item name="rule" label={t('nodes.rule')}><Input placeholder={t('nodes.rulePlaceholder')} /></Form.Item>
-            <Form.Item name="proxy" label={t('nodes.proxy')}><Input placeholder={t('nodes.proxyPlaceholder')} /></Form.Item>
-          </Space>
-          <ProtocolForm protocol={protocol} />
-          <Form.Item name="enabled" label={t('nodes.enabled')} valuePropName="checked"><Switch /></Form.Item>
-          <Text type="secondary">{t('nodes.protocolHint')}</Text>
-        </Form>
-      </Modal>
-
-      <Modal title={`${t('nodes.clientConfig')} — ${access?.name || ''}`} open={accessOpen} onCancel={() => setAccessOpen(false)} footer={null} width={760} destroyOnClose>
-        <Paragraph type="secondary">{t('nodes.clientConfigHint')}</Paragraph>
-        <Space direction="vertical" style={{ width: '100%' }}>
-          {access && ([
-            [t('nodes.mihomoClash'), access.clash_link], [t('nodes.singbox'), access.singbox_link], [t('nodes.shadowrocket'), access.shadowrocket_link], [t('nodes.rawMihomo'), access.mihomo_link],
-          ] as Array<[string, string]>).map(([label, link]) => (
-            <Space key={label} style={{ display: 'flex' }}><Text strong style={{ width: 130 }}>{label}</Text><Input value={link} readOnly style={{ minWidth: 430 }} /><Button icon={<CopyOutlined />} onClick={() => void copy(link)}>{t('nodes.copy')}</Button></Space>
-          ))}
-        </Space>
-      </Modal>
-    </div>
-  );
+  return <div>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}><div><Title level={2} style={{ margin: 0 }}>{title}</Title><Paragraph style={{ margin: 0 }}>{subtitle}</Paragraph></div><Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>{t('nodes.create')}</Button></div>
+    <Table rowKey="ID" loading={loading} dataSource={rows} columns={columns} scroll={{ x: 'max-content' }} />
+    <Modal title={editing ? t('nodes.editTitle') : t('nodes.createTitle')} open={open} onOk={() => void save()} onCancel={() => setOpen(false)} confirmLoading={saving} destroyOnClose width={820}>
+      <Form form={form} layout="vertical"><Form.Item name="name" label={t('nodes.name')} rules={[{ required: true, message: t('nodes.nameRequired') }]}><Input /></Form.Item>
+        <Space style={{ display: 'flex' }} align="start"><Form.Item name="protocol" label={listenerLabel} rules={[{ required: true }]} style={{ width: 280 }}><Select options={LISTENER_PROTOCOLS.map((value) => ({ value, label: protocolLabels[value] }))} onChange={() => form.setFieldValue('protocolConfig', {})} /></Form.Item><Form.Item name="port" label={t('nodes.port')} rules={[{ required: true }]} style={{ width: 180 }}><InputNumber min={1} max={65535} style={{ width: '100%' }} /></Form.Item><Form.Item name="bind_address" label={t('nodes.listenAddress')} rules={[{ required: true }]} style={{ width: 220 }}><Input placeholder="0.0.0.0" /></Form.Item></Space>
+        <Space style={{ display: 'flex' }} align="start"><Form.Item name="rule" label={t('nodes.rule')}><Input placeholder={t('nodes.rulePlaceholder')} /></Form.Item><Form.Item name="proxy" label={t('nodes.proxy')}><Input placeholder={t('nodes.proxyPlaceholder')} /></Form.Item></Space>
+        <ProtocolForm protocol={protocol} /><Form.Item name="enabled" label={t('nodes.enabled')} valuePropName="checked"><Switch /></Form.Item><Text type="secondary">{t('nodes.protocolHint')}</Text>
+      </Form>
+    </Modal>
+    <Modal title={`${t('nodes.clientConfig')} — ${access?.name || ''}`} open={accessOpen} onCancel={() => setAccessOpen(false)} footer={null} width={760} destroyOnClose><Paragraph type="secondary">{clientHint}</Paragraph><Space direction="vertical" style={{ width: '100%' }}>{access && ([[t('nodes.mihomoClash'), access.clash_link], [t('nodes.singbox'), access.singbox_link], [t('nodes.shadowrocket'), access.shadowrocket_link], [t('nodes.rawMihomo'), access.mihomo_link]] as Array<[string, string]>).map(([label, link]) => <Space key={label} style={{ display: 'flex' }}><Text strong style={{ width: 130 }}>{label}</Text><Input value={link} readOnly style={{ minWidth: 430 }} /><Button icon={<CopyOutlined />} onClick={() => void copy(link)}>{t('nodes.copy')}</Button></Space>)}</Space></Modal>
+  </div>;
 };
 
 export default NodesPage;


### PR DESCRIPTION
## Summary

- Automatically generate and persist stable client credentials for listener protocols that require them.
- Repair legacy nodes during client export so existing nodes created before embedded credentials can still generate subscriptions.
- Keep Proxy User bindings only as a legacy fallback; normal node export no longer depends on Proxy User management.
- Add localized node table/action labels and remove visible mixed-language Listener descriptions from the Nodes page.
- Add regression coverage for automatic VLESS credential generation.

## Fixes

This addresses client export failures such as `listener "11111" requires at least one active user for vless client export`, while preserving the unified Node = Listener = client configuration model.