### PR TITLE
feat: integrate ClashMeta inbound templates

### DIFF
--- a/backend/internal/inboundtemplate/api.go
+++ b/backend/internal/inboundtemplate/api.go
@@ -1,0 +1,43 @@
+package inboundtemplate
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kazeyukiro/3m-ui/backend/internal/database/models"
+	"github.com/kazeyukiro/3m-ui/backend/internal/user"
+)
+
+type Handler struct {
+	nodeCreate func(*models.Listener) error
+	userCreate func(user.CreateInput) (*models.ProxyUser, error)
+	bind       func(uint, []uint) error
+}
+
+func NewHandler(nodeCreate func(*models.Listener) error, userCreate func(user.CreateInput) (*models.ProxyUser, error), bind func(uint, []uint) error) *Handler {
+	return &Handler{nodeCreate: nodeCreate, userCreate: userCreate, bind: bind}
+}
+
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+	rg.GET("", h.List)
+	rg.POST("/:id/create", h.Create)
+}
+
+func (h *Handler) List(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"templates": List()})
+}
+
+func (h *Handler) Create(c *gin.Context) {
+	var input CreateInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if input.TemplateID == "" { input.TemplateID = c.Param("id") }
+	listener, proxyUser, err := Create(input, h.nodeCreate, h.userCreate, h.bind)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"listener": listener, "proxy_user": proxyUser})
+}

--- a/backend/internal/inboundtemplate/service.go
+++ b/backend/internal/inboundtemplate/service.go
@@ -1,0 +1,178 @@
+package inboundtemplate
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kazeyukiro/3m-ui/backend/internal/database/models"
+	"github.com/kazeyukiro/3m-ui/backend/internal/user"
+)
+
+type Template struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Protocol    string   `json:"protocol"`
+	Fields      []Field  `json:"fields"`
+}
+
+type Field struct {
+	Name     string `json:"name"`
+	Label    string `json:"label"`
+	Required bool   `json:"required"`
+	Secret   bool   `json:"secret"`
+	Default  string `json:"default,omitempty"`
+}
+
+type CreateInput struct {
+	TemplateID string            `json:"template_id" binding:"required"`
+	Name       string            `json:"name"`
+	Port       string            `json:"port"`
+	Bind       string            `json:"bind"`
+	Username   string            `json:"username"`
+	Password   string            `json:"password"`
+	UUID       string            `json:"uuid"`
+	Values     map[string]string `json:"values"`
+}
+
+var templates = []Template{
+	{ID: "vless-reality-tcp-vision", Name: "VLESS Reality TCP Vision", Description: "VLESS + Reality + XTLS Vision", Protocol: "vless", Fields: []Field{
+		{Name: "dest", Label: "Reality 目标", Required: true, Default: "example.com:443"},
+		{Name: "server_name", Label: "ServerName", Required: true, Default: "example.com"},
+		{Name: "private_key", Label: "Reality PrivateKey", Required: false, Secret: true, Default: "auto"},
+		{Name: "short_id", Label: "ShortID", Required: false, Secret: true, Default: "auto"},
+	}},
+	{ID: "vless-encryption-tcp-vision", Name: "VLESS Encryption TCP Vision", Description: "VLESS Encryption + XTLS Vision", Protocol: "vless", Fields: []Field{
+		{Name: "decryption", Label: "Decryption", Required: true, Secret: true},
+	}},
+	{ID: "vless-enc-tls-xhttp-cdn", Name: "VLESS Encryption TLS XHTTP CDN", Description: "VLESS + Encryption + TLS + XHTTP", Protocol: "vless", Fields: []Field{
+		{Name: "decryption", Label: "Decryption", Required: true, Secret: true},
+		{Name: "certificate", Label: "证书路径", Required: true, Default: "./cert.pem"},
+		{Name: "private_key", Label: "私钥路径", Required: true, Secret: true, Default: "./cert.key"},
+		{Name: "host", Label: "XHTTP Host", Required: false},
+		{Name: "path", Label: "XHTTP Path", Required: true, Default: "/xhttp"},
+	}},
+	{ID: "vless-tls-xhttp-h2-pinned", Name: "VLESS TLS XHTTP H2", Description: "VLESS + TLS + XHTTP", Protocol: "vless", Fields: []Field{
+		{Name: "certificate", Label: "证书路径", Required: true, Default: "./server.pem"},
+		{Name: "private_key", Label: "私钥路径", Required: true, Secret: true, Default: "./server.key"},
+		{Name: "host", Label: "XHTTP Host", Required: false},
+		{Name: "path", Label: "XHTTP Path", Required: true, Default: "/xhttp"},
+	}},
+	{ID: "hysteria2-ech", Name: "Hysteria2 ECH", Description: "Hysteria2 + TLS + ECH", Protocol: "hysteria2", Fields: []Field{
+		{Name: "certificate", Label: "证书路径", Required: true, Default: "./server.crt"},
+		{Name: "private_key", Label: "私钥路径", Required: true, Secret: true, Default: "./server.key"},
+		{Name: "ech_key", Label: "ECH Key", Required: false, Secret: true},
+		{Name: "up", Label: "上行限速", Required: false, Default: "50"},
+		{Name: "down", Label: "下行限速", Required: false, Default: "20"},
+	}},
+	{ID: "shadowquic", Name: "ShadowQuic", Description: "ShadowQuic + JLS + QUIC", Protocol: "shadowquic", Fields: []Field{
+		{Name: "jls_addr", Label: "JLS 目标", Required: true, Default: "example.com:443"},
+		{Name: "jls_sni", Label: "JLS SNI", Required: true, Default: "example.com"},
+	}},
+}
+
+func List() []Template { return append([]Template(nil), templates...) }
+
+func Find(id string) (Template, bool) {
+	for _, item := range templates {
+		if item.ID == id {
+			return item, true
+		}
+	}
+	return Template{}, false
+}
+
+func Create(input CreateInput, nodeCreator func(*models.Listener) error, userCreator func(user.CreateInput) (*models.ProxyUser, error), binder func(uint, []uint) error) (*models.Listener, *models.ProxyUser, error) {
+	t, ok := Find(strings.TrimSpace(input.TemplateID))
+	if !ok {
+		return nil, nil, fmt.Errorf("unknown inbound template %q", input.TemplateID)
+	}
+	port := strings.TrimSpace(input.Port)
+	if port == "" {
+		port = "443"
+	}
+	bind := strings.TrimSpace(input.Bind)
+	if bind == "" {
+		bind = "0.0.0.0"
+	}
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		name = t.Name
+	}
+
+	values := map[string]string{}
+	for k, v := range input.Values { values[k] = strings.TrimSpace(v) }
+	for _, f := range t.Fields {
+		if values[f.Name] == "" && f.Default != "" && f.Default != "auto" { values[f.Name] = f.Default }
+		if f.Required && values[f.Name] == "" { return nil, nil, fmt.Errorf("field %q is required", f.Label) }
+	}
+
+	cfg := map[string]interface{}{}
+	var proxyUser *models.ProxyUser
+	username := strings.TrimSpace(input.Username)
+	password := input.Password
+	uuid := strings.TrimSpace(input.UUID)
+	if username == "" { username = "user1" }
+
+	switch t.ID {
+	case "vless-reality-tcp-vision":
+		if uuid == "" { uuid = randomUUID() }
+		privateKey := values["private_key"]
+		if privateKey == "" || privateKey == "auto" { privateKey = realityPrivateKey() }
+		shortID := values["short_id"]
+		if shortID == "" || shortID == "auto" { shortID = randomHex(8) }
+		cfg["users"] = []map[string]interface{}{{"username": username, "uuid": uuid, "flow": "xtls-rprx-vision"}}
+		cfg["reality-config"] = map[string]interface{}{"dest": values["dest"], "private-key": privateKey, "short-id": []string{shortID}, "server-names": []string{values["server_name"]}}
+	case "vless-encryption-tcp-vision":
+		if uuid == "" { uuid = randomUUID() }
+		cfg["users"] = []map[string]interface{}{{"username": username, "uuid": uuid, "flow": "xtls-rprx-vision"}}
+		cfg["decryption"] = values["decryption"]
+	case "vless-enc-tls-xhttp-cdn", "vless-tls-xhttp-h2-pinned":
+		if uuid == "" { uuid = randomUUID() }
+		cfg["users"] = []map[string]interface{}{{"username": username, "uuid": uuid}}
+		if t.ID == "vless-enc-tls-xhttp-cdn" { cfg["decryption"] = values["decryption"] }
+		cfg["certificate"], cfg["private-key"] = values["certificate"], values["private_key"]
+		cfg["xhttp-config"] = map[string]interface{}{"host": values["host"], "path": values["path"], "mode": "auto"}
+	case "hysteria2-ech":
+		if password == "" { password = randomToken(24) }
+		cfg["users"] = map[string]string{username: password}
+		cfg["certificate"], cfg["private-key"] = values["certificate"], values["private_key"]
+		if values["ech_key"] != "" { cfg["ech-key"] = values["ech_key"] }
+		if values["up"] != "" { cfg["up"] = values["up"] }
+		if values["down"] != "" { cfg["down"] = values["down"] }
+		cfg["alpn"] = []string{"h3"}
+	case "shadowquic":
+		if password == "" { password = randomToken(24) }
+		cfg["users"] = []map[string]string{{"username": username, "password": password}}
+		cfg["quic-versions"] = []string{"v2"}
+		cfg["congestion-controller"] = "bbr"
+		cfg["jls-upstream"] = map[string]interface{}{"addr": values["jls_addr"], "sni": values["jls_sni"]}
+		cfg["alpn"] = []string{"h3"}
+	}
+
+	encoded, err := json.Marshal(cfg)
+	if err != nil { return nil, nil, fmt.Errorf("encode template: %w", err) }
+	listener := &models.Listener{Name: name, Protocol: t.Protocol, Type: t.Protocol, Port: port, BindAddress: bind, Enabled: true, UDP: t.Protocol == "hysteria2" || t.Protocol == "shadowquic", Config: string(encoded)}
+	if err := nodeCreator(listener); err != nil { return nil, nil, err }
+
+	// Keep the generated credential in the normal 3m-ui user model so quota,
+	// expiry, bindings and URI export remain consistent with manually-created users.
+	if t.Protocol == "vless" || t.Protocol == "hysteria2" || t.Protocol == "shadowquic" {
+		proxyUser, err = userCreator(user.CreateInput{Username: username, Password: password, UUID: uuid, Enabled: ptr(true)})
+		if err != nil { return listener, nil, err }
+		if err := binder(proxyUser.ID, []uint{listener.ID}); err != nil { return listener, proxyUser, err }
+	}
+	return listener, proxyUser, nil
+}
+
+func ptr(v bool) *bool { return &v }
+func randomUUID() string { return randomHexUUID() }
+func randomHexUUID() string { b := make([]byte, 16); _, _ = rand.Read(b); b[6] = (b[6]&0x0f)|0x40; b[8] = (b[8]&0x3f)|0x80; return fmt.Sprintf("%s-%s-%s-%s-%s", hex.EncodeToString(b[:4]), hex.EncodeToString(b[4:6]), hex.EncodeToString(b[6:8]), hex.EncodeToString(b[8:10]), hex.EncodeToString(b[10:])) }
+func randomHex(n int) string { b := make([]byte, n); _, _ = rand.Read(b); return hex.EncodeToString(b) }
+func randomToken(n int) string { b := make([]byte, n); _, _ = rand.Read(b); return base64.RawURLEncoding.EncodeToString(b) }
+func realityPrivateKey() string { key, err := ecdh.X25519().GenerateKey(rand.Reader); if err != nil { return "" }; return base64.RawURLEncoding.EncodeToString(key.Bytes()) }

--- a/backend/internal/inboundtemplate/service_test.go
+++ b/backend/internal/inboundtemplate/service_test.go
@@ -1,0 +1,33 @@
+package inboundtemplate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kazeyukiro/3m-ui/backend/internal/database/models"
+	"github.com/kazeyukiro/3m-ui/backend/internal/user"
+)
+
+func TestListIncludesClashMetaTemplates(t *testing.T) {
+	items := List()
+	if len(items) < 6 { t.Fatalf("expected at least 6 templates, got %d", len(items)) }
+	if _, ok := Find("vless-reality-tcp-vision"); !ok { t.Fatal("Reality template missing") }
+	if _, ok := Find("hysteria2-ech"); !ok { t.Fatal("Hysteria2 template missing") }
+}
+
+func TestCreateVLESSReality(t *testing.T) {
+	var saved *models.Listener
+	var created *models.ProxyUser
+	listener, proxyUser, err := Create(CreateInput{TemplateID:"vless-reality-tcp-vision", Port:"443", Username:"alice", Values:map[string]string{"dest":"example.com:443","server_name":"example.com"}}, func(l *models.Listener) error { saved=l; l.ID=1; return nil }, func(in user.CreateInput) (*models.ProxyUser,error) { created=&models.ProxyUser{ID:2,Username:in.Username,UUID:in.UUID}; return created,nil }, func(uint,[]uint) error { return nil })
+	if err != nil { t.Fatal(err) }
+	if listener != saved || proxyUser != created { t.Fatal("unexpected returned objects") }
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(saved.Config), &cfg); err != nil { t.Fatal(err) }
+	if cfg["reality-config"] == nil { t.Fatal("missing reality config") }
+	if cfg["users"] == nil { t.Fatal("missing users") }
+}
+
+func TestPasswordBasedTemplatesRequirePassword(t *testing.T) {
+	_, _, err := Create(CreateInput{TemplateID:"shadowquic", Values:map[string]string{"jls_addr":"example.com:443","jls_sni":"example.com"}}, func(*models.Listener) error { t.Fatal("listener should not be created"); return nil }, func(user.CreateInput) (*models.ProxyUser,error) { t.Fatal("user should not be created"); return nil,nil }, func(uint,[]uint) error { return nil })
+	if err == nil { t.Fatal("expected password validation error") }
+}

--- a/frontend/src/pages/InboundTemplates.tsx
+++ b/frontend/src/pages/InboundTemplates.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Button, Card, Form, Input, InputNumber, Select, Space, message } from 'antd';
+import client from '../api/client';
+
+type Field = { name: string; label: string; required: boolean; secret: boolean; default?: string };
+type Template = { id: string; name: string; description: string; protocol: string; fields: Field[] };
+
+const InboundTemplates: React.FC = () => {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [selected, setSelected] = useState<string>();
+  const [loading, setLoading] = useState(false);
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    client.get('/inbound-templates').then(({ data }) => setTemplates(data.templates || [])).catch((err) => message.error(err.message));
+  }, []);
+
+  const template = templates.find((item) => item.id === selected);
+
+  const submit = async (values: Record<string, string>) => {
+    if (!template) return;
+    setLoading(true);
+    try {
+      const { data } = await client.post(`/inbound-templates/${template.id}/create`, {
+        template_id: template.id,
+        name: values.name,
+        port: String(values.port || '443'),
+        bind: values.bind || '0.0.0.0',
+        username: values.username || 'user1',
+        password: values.password,
+        uuid: values.uuid,
+        values: Object.fromEntries(template.fields.map((field) => [field.name, values[field.name] || ''])),
+      });
+      message.success(`节点「${data.listener.name}」创建成功`);
+      form.resetFields();
+    } catch (err: any) {
+      message.error(err.message || '创建失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <div>
+        <h2 style={{ marginBottom: 4 }}>快速创建节点</h2>
+        <div style={{ color: '#666' }}>基于 Mihomo Inbound 模板一键创建 Listener、凭据并应用配置。</div>
+      </div>
+      <Card>
+        <Form layout="vertical" form={form} onFinish={submit} initialValues={{ port: 443, bind: '0.0.0.0', username: 'user1' }}>
+          <Form.Item label="节点模板" required>
+            <Select placeholder="选择模板" value={selected} onChange={(value) => { setSelected(value); form.resetFields(); }} options={templates.map((item) => ({ value: item.id, label: `${item.name} — ${item.description}` }))} />
+          </Form.Item>
+          {template && <Alert style={{ marginBottom: 16 }} type="info" message={`协议：${template.protocol}`} description="模板参数会写入 Listener 配置；VLESS 的 UUID/Reality 密钥可以自动生成。证书、Decryption、ECH 等外部材料仍需提前准备。" />}
+          <Space wrap style={{ width: '100%' }}>
+            <Form.Item name="name" label="节点名称" rules={[{ required: true, message: '请输入节点名称' }]}><Input style={{ width: 220 }} /></Form.Item>
+            <Form.Item name="port" label="端口" rules={[{ required: true }]}><InputNumber min={1} max={65535} style={{ width: 140 }} /></Form.Item>
+            <Form.Item name="bind" label="监听地址"><Input style={{ width: 180 }} /></Form.Item>
+            <Form.Item name="username" label="用户名"><Input style={{ width: 180 }} /></Form.Item>
+            {template?.protocol !== 'vless' && template && <Form.Item name="password" label="密码" rules={[{ required: true, message: '请输入密码' }]}><Input.Password style={{ width: 220 }} /></Form.Item>}
+          </Space>
+          {template?.protocol === 'vless' && <Form.Item name="uuid" label="UUID（留空自动生成）"><Input style={{ maxWidth: 420 }} /></Form.Item>}
+          {template?.fields.map((field) => (
+            <Form.Item key={field.name} name={field.name} label={field.label} initialValue={field.default === 'auto' ? undefined : field.default} rules={[{ required: field.required, message: `请输入${field.label}` }]}>
+              {field.secret ? <Input.Password placeholder={field.default === 'auto' ? '留空自动生成' : undefined} /> : <Input />}
+            </Form.Item>
+          ))}
+          <Button type="primary" htmlType="submit" loading={loading} disabled={!template}>一键创建并应用</Button>
+        </Form>
+      </Card>
+    </Space>
+  );
+};
+
+export default InboundTemplates;


### PR DESCRIPTION
## 变更
- 集成 `clashmeta-inbound` 模板思路，提供 6 个 Mihomo Inbound 快速创建模板。
- 新增 `/api/v1/inbound-templates` 模板列表及一键创建 API。
- 创建时复用现有 Listener、ProxyUser、绑定和配置热更新链路，不新增独立用户体系。
- 新增“快速创建节点”中文页面和侧边栏入口。
- VLESS Reality 自动生成 UUID、Reality X25519 私钥和 ShortID。
- Hysteria2 / ShadowQuic 要求显式提供密码，避免随机生成后用户无法获知。
- 保留证书、Decryption、ECH 等外部材料为用户输入，不自动伪造。

## 模板
- VLESS Reality TCP Vision
- VLESS Encryption TCP Vision
- VLESS Encryption TLS XHTTP CDN
- VLESS TLS XHTTP H2
- Hysteria2 ECH
- ShadowQuic

## 兼容性
- 不修改现有 Listener API。
- 不修改初始管理员密码，仍为 `admin`。
- 复用现有 ProxyUser quota/expiry/binding/URI export 逻辑。

## 验证
- 新增 inbound template 单元测试。