### PR TITLE
fix: repair build artifacts and auth regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,28 @@ GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildTime=$(BUILD_TIME)
 
-.PHONY: build build-linux build-linux-static release clean
+.PHONY: build frontend-assets build-linux build-linux-static release clean
 
-build:
-	mkdir -p $(DIST_DIR)
+# Build the web UI and copy the complete Vite output into the directory used
+# by go:embed. Every binary target depends on this so standalone Linux builds
+# never ship with stale or missing frontend assets.
+frontend-assets:
 	cd $(FRONTEND_DIR) && npm install && npm run build
 	rm -rf $(BACKEND_DIR)/cmd/server/web/dist
+	mkdir -p $(BACKEND_DIR)/cmd/server/web
 	cp -R $(FRONTEND_DIR)/dist $(BACKEND_DIR)/cmd/server/web/dist
+
+build: frontend-assets
+	mkdir -p $(DIST_DIR)
 	cd $(BACKEND_DIR) && go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME) ./cmd/server
 
-build-linux:
+build-linux: frontend-assets
 	mkdir -p $(DIST_DIR)
 	cd $(BACKEND_DIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-amd64 ./cmd/server
 	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-arm64 ./cmd/server
 	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-armv7 ./cmd/server
 
-build-linux-static:
+build-linux-static: frontend-assets
 	mkdir -p $(DIST_DIR)
 	cd $(BACKEND_DIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags sqlite_modernc -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-amd64-static ./cmd/server
 	cd $(BACKEND_DIR) && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags sqlite_modernc -trimpath -ldflags "$(LDFLAGS)" -o ../$(DIST_DIR)/$(APP_NAME)-linux-arm64-static ./cmd/server

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -11,10 +11,10 @@ import (
 
 // JWTClaims represents the authenticated administrator identity.
 type JWTClaims struct {
-	UserID         uint   `json:"user_id"`
-	Username       string `json:"username"`
-	Role           string `json:"role"`
-	SessionVersion uint
+	UserID         uint      `json:"user_id"`
+	Username       string    `json:"username"`
+	Role           string    `json:"role"`
+	SessionVersion uint      `json:"session_version"`
 	ExpiresAt      time.Time `json:"expires_at"`
 }
 
@@ -51,7 +51,7 @@ func ParseToken(secret, tokenString string) (*JWTClaims, error) {
 		return []byte(secret), nil
 	}, jwt.WithValidMethods([]string{"HS256"}))
 	if err != nil {
-		return nil, fmt.Errorf("invalid or expired token")
+		return nil, errors.New("invalid or expired token")
 	}
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
@@ -84,9 +84,9 @@ func ParseToken(secret, tokenString string) (*JWTClaims, error) {
 
 // TokenFromRequest extracts the Bearer token from the Authorization header.
 func TokenFromRequest(authHeader string) string {
-const prefix = "Bearer "
-if strings.HasPrefix(authHeader, prefix) {
-return strings.TrimSpace(authHeader[len(prefix):])
-}
-return ""
+	const prefix = "Bearer "
+	if strings.HasPrefix(authHeader, prefix) {
+		return strings.TrimSpace(authHeader[len(prefix):])
+	}
+	return ""
 }

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenFromRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{name: "bearer", header: "Bearer abc.def.ghi", want: "abc.def.ghi"},
+		{name: "bearer with surrounding whitespace", header: "Bearer   abc", want: "abc"},
+		{name: "wrong scheme", header: "Basic abc", want: ""},
+		{name: "empty", header: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TokenFromRequest(tt.header); got != tt.want {
+				t.Fatalf("TokenFromRequest(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJWTTokenRoundTrip(t *testing.T) {
+	secret := "test-secret"
+	token, expiresAt, err := GenerateToken(secret, 42, "admin", "admin", 7, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if expiresAt.Before(time.Now()) {
+		t.Fatal("generated token is already expired")
+	}
+
+	claims, err := ParseToken(secret, token)
+	if err != nil {
+		t.Fatalf("ParseToken() error = %v", err)
+	}
+	if claims.UserID != 42 || claims.Username != "admin" || claims.Role != "admin" || claims.SessionVersion != 7 {
+		t.Fatalf("unexpected claims: %+v", claims)
+	}
+}


### PR DESCRIPTION
修复 main 中发现的构建与认证相关问题。

- 修复所有 Makefile Linux 构建目标未刷新嵌入式前端资源的问题，避免 standalone build 使用过期/缺失的 web/dist。
- 统一 frontend-assets 依赖，让 build/build-linux/build-linux-static 都先生成完整前端资源。
- 修正 TokenFromRequest 格式，并为 JWT claims 补充 session_version JSON tag。
- 增加 Bearer Token 解析和 JWT round-trip 单元测试。

明确不修改初始管理员密码，保持现有 `admin` 初始密码逻辑不变。