### PR TITLE
fix: repair node ID JSON serialization

### DIFF
--- a/backend/internal/database/models/listener.go
+++ b/backend/internal/database/models/listener.go
@@ -1,21 +1,28 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type Listener struct {
-	gorm.Model
-	Name        string `gorm:"not null" json:"name"`
-	Protocol    string `gorm:"type:varchar(50);not null;default:'shadowsocks'" json:"protocol"`
-	Type        string `gorm:"type:varchar(50)" json:"type"`
-	Port        string `gorm:"type:varchar(50);not null;default:'0'" json:"port"`
-	BindAddress string `gorm:"type:varchar(100);not null;default:'0.0.0.0'" json:"bind_address"`
-	Listen      string `gorm:"type:varchar(100)" json:"listen"`
-	TLS         bool   `gorm:"not null;default:false" json:"tls,omitempty"`
-	UDP         bool   `gorm:"not null;default:false" json:"udp,omitempty"`
-	Enabled     bool   `gorm:"not null;default:false" json:"enabled"`
-	Proxy       string `gorm:"type:varchar(255)" json:"proxy,omitempty"`
-	Rule        string `gorm:"type:text" json:"rule,omitempty"`
-	Config      string `gorm:"type:text" json:"config"`
-	Status      string `gorm:"type:varchar(50);default:'inactive'" json:"status"`
-	RoutingMark int    `gorm:"default:0" json:"routing_mark,omitempty"`
+	ID          uint           `gorm:"primaryKey" json:"id"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	Name        string         `gorm:"not null" json:"name"`
+	Protocol    string         `gorm:"type:varchar(50);not null;default:'shadowsocks'" json:"protocol"`
+	Type        string         `gorm:"type:varchar(50)" json:"type"`
+	Port        string         `gorm:"type:varchar(50);not null;default:'0'" json:"port"`
+	BindAddress string         `gorm:"type:varchar(100);not null;default:'0.0.0.0'" json:"bind_address"`
+	Listen      string         `gorm:"type:varchar(100)" json:"listen"`
+	TLS         bool           `gorm:"not null;default:false" json:"tls,omitempty"`
+	UDP         bool           `gorm:"not null;default:false" json:"udp,omitempty"`
+	Enabled     bool           `gorm:"not null;default:false" json:"enabled"`
+	Proxy       string         `gorm:"type:varchar(255)" json:"proxy,omitempty"`
+	Rule        string         `gorm:"type:text" json:"rule,omitempty"`
+	Config      string         `gorm:"type:text" json:"config"`
+	Status      string         `gorm:"type:varchar(50);default:'inactive'" json:"status"`
+	RoutingMark int            `gorm:"default:0" json:"routing_mark,omitempty"`
 }

--- a/backend/internal/database/models/listener_test.go
+++ b/backend/internal/database/models/listener_test.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestListenerJSONUsesLowercaseID(t *testing.T) {
+	listener := Listener{ID: 42, Name: "test-listener"}
+
+	data, err := json.Marshal(listener)
+	if err != nil {
+		t.Fatalf("marshal listener: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal listener JSON: %v", err)
+	}
+
+	if got, ok := payload["id"].(float64); !ok || got != 42 {
+		t.Fatalf("expected JSON id=42, got %#v", payload["id"])
+	}
+	if _, ok := payload["ID"]; ok {
+		t.Fatalf("listener JSON must not expose an uppercase ID field")
+	}
+}


### PR DESCRIPTION
修复节点删除时报 `invalid node id` 的问题。

根因是 `models.Listener` 嵌入 `gorm.Model` 后，ID 被 JSON 序列化为 `ID`，而前端读取的是 `id`，导致请求 `/nodes/undefined`。

本 PR：
- 明确声明 Listener 的 ID/时间字段并将 ID 序列化为 `id`
- 保持 GORM 主键、软删除字段兼容
- 增加 JSON 回归测试，防止再次出现 `ID`/`id` 不一致

初始管理员密码逻辑未修改，仍为 `admin`。