### PR TITLE
fix: correct installer and updater repository

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eu
 umask 077
 
-REPO="dzx941/3m-ui"
+REPO="kazeyukiro/3m-ui"
 BASE="/usr/local/lib/3m-ui"
 APP_BIN="$BASE/3m-ui-bin"
 VERSION_FILE="$BASE/VERSION"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,7 +2,7 @@
 set -eu
 umask 077
 
-REPO="dzx941/3m-ui"
+REPO="kazeyukiro/3m-ui"
 BASE="/usr/local/lib/3m-ui"
 APP_BIN="$BASE/3m-ui-bin"
 VERSION_FILE="$BASE/VERSION"


### PR DESCRIPTION
Audit found a release-management bug: install.sh and update.sh were hardcoded to download 3m-ui releases and scripts from `dzx941/3m-ui`, while this repository is `kazeyukiro/3m-ui`. This would make fresh installs and updates target the wrong repository.

Changes:
- Correct `REPO` in scripts/install.sh.
- Correct `REPO` in scripts/update.sh.
- Initial administrator password behavior was not changed.

The changes are limited to the deployment scripts.