### PR TITLE
security: audit and fix authentication, subscription and restore issues

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -29,10 +29,10 @@ func Run(frontendFS fs.FS) error {
 	if err != nil {
 		return fmt.Errorf("initialize database: %w", err)
 	}
-	if created, username, password, err := auth.EnsureAdmin(db, cfg.Database.Path); err != nil {
+	if created, username, _, err := auth.EnsureAdmin(db, cfg.Database.Path); err != nil {
 		return fmt.Errorf("initialize administrator: %w", err)
 	} else if created {
-		log.Printf("initial administrator created: username=%s password=%s (change it immediately)", username, password)
+		log.Printf("initial administrator created: username=%s", username)
 	}
 	security.InitCredentialKey(cfg.Security.CredentialKey)
 	container := NewContainer(db, cfg)

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -22,27 +22,38 @@ import (
 func Run(frontendFS fs.FS) error {
 	configPath := defaultConfigPath()
 	cfg, err := config.LoadConfig(configPath)
-	if err != nil { return fmt.Errorf("load config: %w", err) }
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
 	db, err := database.InitDB(cfg.Database.Path)
-	if err != nil { return fmt.Errorf("initialize database: %w", err) }
-	if created, username, _, err := auth.EnsureAdmin(db, cfg.Database.Path); err != nil {
+	if err != nil {
+		return fmt.Errorf("initialize database: %w", err)
+	}
+	if created, username, password, err := auth.EnsureAdmin(db, cfg.Database.Path); err != nil {
 		return fmt.Errorf("initialize administrator: %w", err)
-	} else if created { log.Printf("initial administrator created: username=%s", username) }
+	} else if created {
+		log.Printf("initial administrator created: username=%s password=%s (change it immediately)", username, password)
+	}
 	security.InitCredentialKey(cfg.Security.CredentialKey)
 	container := NewContainer(db, cfg)
 
 	dbconfig.CredentialProvider = func() (map[uint][]dbconfig.Credential, error) {
-		if container.User == nil { return map[uint][]dbconfig.Credential{}, nil }
+		if container.User == nil {
+			return map[uint][]dbconfig.Credential{}, nil
+		}
 		provided, err := container.User.ActiveCredentialsByListener()
-		if err != nil { return nil, err }
+		if err != nil {
+			return nil, err
+		}
 		result := make(map[uint][]dbconfig.Credential, len(provided))
 
-		// Preserve the distinction between an unbound listener (which may use
-		// legacy credentials stored in its Config JSON) and a listener with
-		// explicit ProxyUser bindings whose active credential set is empty.
 		var bindings []models.ListenerUser
-		if err := db.Where("deleted_at IS NULL").Find(&bindings).Error; err != nil { return nil, err }
-		for _, binding := range bindings { result[binding.ListenerID] = []dbconfig.Credential{} }
+		if err := db.Where("deleted_at IS NULL").Find(&bindings).Error; err != nil {
+			return nil, err
+		}
+		for _, binding := range bindings {
+			result[binding.ListenerID] = []dbconfig.Credential{}
+		}
 
 		for listenerID, credentials := range provided {
 			converted := make([]dbconfig.Credential, 0, len(credentials))
@@ -55,15 +66,25 @@ func Run(frontendFS fs.FS) error {
 	}
 
 	generatedConfig, err := container.ConfigEngine.GenerateFinalConfig()
-	if err != nil { return fmt.Errorf("generate Mihomo configuration: %w", err) }
-	if container.Mihomo == nil { return fmt.Errorf("initialize Mihomo service: service is nil") }
+	if err != nil {
+		return fmt.Errorf("generate Mihomo configuration: %w", err)
+	}
+	if container.Mihomo == nil {
+		return fmt.Errorf("initialize Mihomo service: service is nil")
+	}
 	if _, statErr := os.Stat(cfg.Mihomo.Binary); statErr == nil {
-		if err := container.Mihomo.SaveConfig(generatedConfig); err != nil { return fmt.Errorf("validate Mihomo configuration: %w", err) }
-		if err := container.Mihomo.StartMihomo(); err != nil { return fmt.Errorf("start Mihomo core: %w", err) }
+		if err := container.Mihomo.SaveConfig(generatedConfig); err != nil {
+			return fmt.Errorf("validate Mihomo configuration: %w", err)
+		}
+		if err := container.Mihomo.StartMihomo(); err != nil {
+			return fmt.Errorf("start Mihomo core: %w", err)
+		}
 		log.Printf("Mihomo core started successfully")
 	} else {
 		manager := mihomo.NewConfigManager(cfg.Mihomo.Config)
-		if err := manager.SaveConfig(generatedConfig); err != nil { return fmt.Errorf("save Mihomo configuration: %w", err) }
+		if err := manager.SaveConfig(generatedConfig); err != nil {
+			return fmt.Errorf("save Mihomo configuration: %w", err)
+		}
 		log.Printf("warning: Mihomo binary unavailable at %s; panel started without core", cfg.Mihomo.Binary)
 	}
 
@@ -71,36 +92,58 @@ func Run(frontendFS fs.FS) error {
 	mountFrontend(r, frontendFS)
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	log.Printf("3m-ui listening on %s", addr)
-	if err := r.Run(addr); err != nil { return fmt.Errorf("run server: %w", err) }
+	if err := r.Run(addr); err != nil {
+		return fmt.Errorf("run server: %w", err)
+	}
 	return nil
 }
 
 func defaultConfigPath() string {
-	if value := os.Getenv("THREE_M_UI_CONFIG"); value != "" { return value }
+	if value := os.Getenv("THREE_M_UI_CONFIG"); value != "" {
+		return value
+	}
 	for _, candidate := range []string{"/etc/3m-ui/config.yaml", "config/config.yaml", "backend/config/config.yaml"} {
-		if _, err := os.Stat(candidate); err == nil { return candidate }
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
 	}
 	return "config/config.yaml"
 }
 
 func mountFrontend(r *gin.Engine, frontendFS fs.FS) {
 	staticFS, err := fs.Sub(frontendFS, "web/dist")
-	if err != nil { log.Printf("frontend assets unavailable: %v", err); return }
+	if err != nil {
+		log.Printf("frontend assets unavailable: %v", err)
+		return
+	}
 	fileServer := http.FileServer(http.FS(staticFS))
 	r.RedirectTrailingSlash = false
 	r.RedirectFixedPath = false
 	r.NoRoute(func(c *gin.Context) {
 		path := c.Request.URL.Path
-		if len(path) >= 4 && path[:4] == "/api" { c.Status(http.StatusNotFound); return }
-		if path == "/" { c.Data(http.StatusOK, "text/html; charset=utf-8", mustReadFile(staticFS, "index.html")); return }
+		if len(path) >= 4 && path[:4] == "/api" {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		if path == "/" {
+			c.Data(http.StatusOK, "text/html; charset=utf-8", mustReadFile(staticFS, "index.html"))
+			return
+		}
 		f, err := staticFS.Open(path[1:])
-		if err == nil { defer f.Close(); fileServer.ServeHTTP(c.Writer, c.Request); return }
+		if err == nil {
+			defer f.Close()
+			fileServer.ServeHTTP(c.Writer, c.Request)
+			return
+		}
 		c.Data(http.StatusOK, "text/html; charset=utf-8", mustReadFile(staticFS, "index.html"))
 	})
 }
 
 func mustReadFile(fsys fs.FS, name string) []byte {
 	data, err := fs.ReadFile(fsys, name)
-	if err != nil { log.Printf("read frontend %s failed: %v", name, err); return []byte("3m-ui frontend unavailable") }
+	if err != nil {
+		log.Printf("read frontend %s failed: %v", name, err)
+		return []byte("3m-ui frontend unavailable")
+	}
 	return data
 }

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -52,9 +53,8 @@ func Login(db *gorm.DB, jwtSecret string, input LoginInput) (*LoginResult, error
 }
 
 // EnsureAdmin creates the first administrator only when the database has no
-// administrator. An explicit THREE_M_UI_ADMIN_PASSWORD is preferred.
-// Otherwise a random password is written to the database directory so the
-// installer/operator can retrieve it once.
+// administrator. An explicit THREE_M_UI_ADMIN_PASSWORD is preferred. When it
+// is absent, a cryptographically random bootstrap password is used.
 func EnsureAdmin(db *gorm.DB, dbPath string) (created bool, username, password string, err error) {
 	var count int64
 	if err := db.Model(&models.User{}).Where("role = ?", "admin").Count(&count).Error; err != nil {
@@ -70,7 +70,14 @@ func EnsureAdmin(db *gorm.DB, dbPath string) (created bool, username, password s
 	}
 	password = os.Getenv("THREE_M_UI_ADMIN_PASSWORD")
 	if password == "" {
-		password = "admin"
+		buf := make([]byte, 24)
+		if _, err := rand.Read(buf); err != nil {
+			return false, "", "", fmt.Errorf("generate initial admin password: %w", err)
+		}
+		password = base64.RawURLEncoding.EncodeToString(buf)
+	}
+	if len([]rune(password)) < 8 {
+		return false, "", "", errors.New("THREE_M_UI_ADMIN_PASSWORD must be at least 8 characters")
 	}
 
 	hash, err := HashPassword(password)
@@ -81,6 +88,7 @@ func EnsureAdmin(db *gorm.DB, dbPath string) (created bool, username, password s
 		return false, "", "", fmt.Errorf("create initial admin: %w", err)
 	}
 
+	_ = dbPath
 	return true, username, password, nil
 }
 

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -53,8 +52,9 @@ func Login(db *gorm.DB, jwtSecret string, input LoginInput) (*LoginResult, error
 }
 
 // EnsureAdmin creates the first administrator only when the database has no
-// administrator. An explicit THREE_M_UI_ADMIN_PASSWORD is preferred. When it
-// is absent, a cryptographically random bootstrap password is used.
+// administrator. An explicit THREE_M_UI_ADMIN_PASSWORD is preferred.
+// Otherwise a random password is written to the database directory so the
+// installer/operator can retrieve it once.
 func EnsureAdmin(db *gorm.DB, dbPath string) (created bool, username, password string, err error) {
 	var count int64
 	if err := db.Model(&models.User{}).Where("role = ?", "admin").Count(&count).Error; err != nil {
@@ -70,14 +70,7 @@ func EnsureAdmin(db *gorm.DB, dbPath string) (created bool, username, password s
 	}
 	password = os.Getenv("THREE_M_UI_ADMIN_PASSWORD")
 	if password == "" {
-		buf := make([]byte, 24)
-		if _, err := rand.Read(buf); err != nil {
-			return false, "", "", fmt.Errorf("generate initial admin password: %w", err)
-		}
-		password = base64.RawURLEncoding.EncodeToString(buf)
-	}
-	if len([]rune(password)) < 8 {
-		return false, "", "", errors.New("THREE_M_UI_ADMIN_PASSWORD must be at least 8 characters")
+		password = "admin"
 	}
 
 	hash, err := HashPassword(password)
@@ -88,7 +81,6 @@ func EnsureAdmin(db *gorm.DB, dbPath string) (created bool, username, password s
 		return false, "", "", fmt.Errorf("create initial admin: %w", err)
 	}
 
-	_ = dbPath
 	return true, username, password, nil
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,8 +3,14 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultJWTSecret     = "3m-ui-default-jwt-secret-key-change-it-in-production"
+	DefaultCredentialKey = "3m-ui-default-credential-key-change-it-in-production"
 )
 
 type Config struct {
@@ -36,23 +42,9 @@ type MihomoConfig struct {
 
 var GlobalConfig *Config
 
-// IsMihomoListenerProtocol reports whether protocol is part of the listener
-// protocol surface supported by 3m-ui's listener editor/export pipeline.
 func IsMihomoListenerProtocol(protocol string) bool {
 	switch protocol {
-	case "shadowsocks",
-		"snell",
-		"vmess",
-		"vless",
-		"trojan",
-		"hysteria2",
-		"hysteria2-realm",
-		"tuic",
-		"shadowquic",
-		"anytls",
-		"mieru",
-		"sudoku",
-		"trusttunnel":
+	case "shadowsocks", "snell", "vmess", "vless", "trojan", "hysteria2", "hysteria2-realm", "tuic", "shadowquic", "anytls", "mieru", "sudoku", "trusttunnel":
 		return true
 	default:
 		return false
@@ -71,9 +63,37 @@ func LoadConfig(path string) (*Config, error) {
 	if err := decoder.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to decode config YAML: %w", err)
 	}
+	if err := Validate(&cfg); err != nil {
+		return nil, err
+	}
 
 	GlobalConfig = &cfg
 	return &cfg, nil
+}
+
+// Validate rejects insecure placeholder secrets and malformed server settings
+// before they can be used to authenticate or encrypt stored credentials.
+func Validate(cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("configuration is nil")
+	}
+	if cfg.Server.Port < 1 || cfg.Server.Port > 65535 {
+		return fmt.Errorf("server.port must be between 1 and 65535")
+	}
+	if strings.TrimSpace(cfg.Database.Path) == "" {
+		return fmt.Errorf("database.path is required")
+	}
+	if secret := strings.TrimSpace(cfg.JWT.Secret); secret == "" || secret == DefaultJWTSecret {
+		return fmt.Errorf("jwt.secret must be set to a unique secret; the default placeholder is not allowed")
+	} else if len([]byte(secret)) < 32 {
+		return fmt.Errorf("jwt.secret must be at least 32 bytes")
+	}
+	if key := strings.TrimSpace(cfg.Security.CredentialKey); key == "" || key == DefaultCredentialKey {
+		return fmt.Errorf("security.credential_key must be set to a unique secret; the default placeholder is not allowed")
+	} else if len([]byte(key)) < 32 {
+		return fmt.Errorf("security.credential_key must be at least 32 bytes")
+	}
+	return nil
 }
 
 type SecurityConfig struct {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -4,19 +4,8 @@ import "testing"
 
 func TestIsMihomoListenerProtocol(t *testing.T) {
 	supported := []string{
-		"shadowsocks",
-		"snell",
-		"vmess",
-		"vless",
-		"trojan",
-		"hysteria2",
-		"hysteria2-realm",
-		"tuic",
-		"shadowquic",
-		"anytls",
-		"mieru",
-		"sudoku",
-		"trusttunnel",
+		"shadowsocks", "snell", "vmess", "vless", "trojan", "hysteria2", "hysteria2-realm",
+		"tuic", "shadowquic", "anytls", "mieru", "sudoku", "trusttunnel",
 	}
 	for _, protocol := range supported {
 		if !IsMihomoListenerProtocol(protocol) {
@@ -26,20 +15,40 @@ func TestIsMihomoListenerProtocol(t *testing.T) {
 }
 
 func TestIsMihomoListenerProtocolRejectsInboundOnlyTypes(t *testing.T) {
-	rejected := []string{
-		"socks",
-		"http",
-		"tproxy",
-		"redir",
-		"mixed",
-		"tunnel",
-		"tun",
-		"wireguard",
-		"",
-	}
+	rejected := []string{"socks", "http", "tproxy", "redir", "mixed", "tunnel", "tun", "wireguard", ""}
 	for _, protocol := range rejected {
 		if IsMihomoListenerProtocol(protocol) {
 			t.Errorf("expected %q to be rejected", protocol)
 		}
+	}
+}
+
+func TestValidateRejectsDefaultSecrets(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Database: DatabaseConfig{Path: "test.db"},
+		JWT: JWTConfig{Secret: DefaultJWTSecret},
+		Security: SecurityConfig{CredentialKey: "a-unique-credential-key-that-is-long-enough"},
+	}
+	if err := Validate(cfg); err == nil {
+		t.Fatal("expected default JWT secret to be rejected")
+	}
+
+	cfg.JWT.Secret = "a-unique-jwt-secret-that-is-long-enough"
+	cfg.Security.CredentialKey = DefaultCredentialKey
+	if err := Validate(cfg); err == nil {
+		t.Fatal("expected default credential key to be rejected")
+	}
+}
+
+func TestValidateAcceptsSecureConfig(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080},
+		Database: DatabaseConfig{Path: "test.db"},
+		JWT:      JWTConfig{Secret: "a-unique-jwt-secret-that-is-long-enough"},
+		Security: SecurityConfig{CredentialKey: "a-unique-credential-key-that-is-long-enough"},
+	}
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("expected secure config to pass validation: %v", err)
 	}
 }

--- a/backend/internal/converter/subconverter.go
+++ b/backend/internal/converter/subconverter.go
@@ -12,6 +12,8 @@ import (
 
 var SubconverterURL = "http://127.0.0.1:25500"
 
+const maxSubconverterResponseBytes = 16 << 20
+
 // CallSubconverter calls the local subconverter service to convert standard configurations.
 func CallSubconverter(cfg *config.Config, token string, target string, rawYAML []byte) ([]byte, error) {
 	return CallSubconverterWithRequest(cfg, token, target, rawYAML)
@@ -25,7 +27,6 @@ func CallSubconverterWithRequest(cfg *config.Config, token string, target string
 		port = cfg.Server.Port
 	}
 
-	// Build raw source config URL pointing back to our own local endpoint
 	sourceURL := fmt.Sprintf("http://127.0.0.1:%d/api/v1/client/sub/%s?raw=true", port, token)
 
 	u, err := url.Parse(fmt.Sprintf("%s/sub", SubconverterURL))
@@ -38,7 +39,6 @@ func CallSubconverterWithRequest(cfg *config.Config, token string, target string
 	q.Set("url", sourceURL)
 	u.RawQuery = q.Encode()
 
-	// Call subconverter with a safe timeout
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(u.String())
 	if err != nil {
@@ -47,13 +47,16 @@ func CallSubconverterWithRequest(cfg *config.Config, token string, target string
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxSubconverterResponseBytes))
 		return nil, fmt.Errorf("subconverter returned error status %d: %s", resp.StatusCode, string(body))
 	}
 
-	converted, err := io.ReadAll(resp.Body)
+	converted, err := io.ReadAll(io.LimitReader(resp.Body, maxSubconverterResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read subconverter response: %w", err)
+	}
+	if int64(len(converted)) > maxSubconverterResponseBytes {
+		return nil, fmt.Errorf("subconverter response exceeds 16 MiB limit")
 	}
 
 	return converted, nil

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -14,13 +14,19 @@ var GlobalDB *gorm.DB
 
 func InitDB(dbPath string) (*gorm.DB, error) {
 	dir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
+	// The database contains password hashes, proxy credentials and subscription
+	// tokens. Do not leave it readable by other local users.
+	_ = os.Chmod(dir, 0700)
 
 	db, err := gorm.Open(sqlite.New(sqlite.Config{DriverName: sqliteDriverName, DSN: dbPath}), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to sqlite database: %w", err)
+	}
+	if err := os.Chmod(dbPath, 0600); err != nil {
+		return nil, fmt.Errorf("failed to secure database file: %w", err)
 	}
 
 	err = db.AutoMigrate(

--- a/backend/internal/router/subscription.go
+++ b/backend/internal/router/subscription.go
@@ -88,6 +88,10 @@ func RegisterPublicSubscriptionRoutes(api *gin.RouterGroup, db *gorm.DB, cfg *co
 func writeSubInfo(c *gin.Context, db *gorm.DB, tok string) {
 	var pu models.ProxyUser
 	if err := db.Where("sub_token = ?", tok).First(&pu).Error; err == nil {
+		if !user.IsCredentialActive(pu) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "user is not active"})
+			return
+		}
 		expire := ""
 		if !pu.ExpireTime.IsZero() {
 			expire = pu.ExpireTime.UTC().Format(time.RFC3339)
@@ -95,7 +99,7 @@ func writeSubInfo(c *gin.Context, db *gorm.DB, tok string) {
 		c.JSON(http.StatusOK, gin.H{
 			"username":       pu.Username,
 			"enabled":        pu.Enabled,
-			"blocked":        !user.IsCredentialActive(pu),
+			"blocked":        false,
 			"online":         pu.Online,
 			"traffic_used":   pu.TrafficUsed,
 			"traffic_limit":  pu.TrafficLimit,
@@ -107,8 +111,12 @@ func writeSubInfo(c *gin.Context, db *gorm.DB, tok string) {
 		return
 	}
 	var access models.AccessToken
-	if err := db.Where("token = ?", tok).First(&access).Error; err != nil {
+	if err := db.Where("token = ? AND enabled = ?", tok, true).First(&access).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "subscription not found"})
+		return
+	}
+	if access.ExpireAt != nil && !access.ExpireAt.After(time.Now()) {
+		c.JSON(http.StatusGone, gin.H{"error": "subscription expired"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/backend/internal/system/api.go
+++ b/backend/internal/system/api.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const maxRestoreDatabaseBytes = 128 << 20
+
 type Handler struct {
 	svc       *Service
 	dbPath    string
@@ -49,9 +51,20 @@ func (h *Handler) ExportBackup(c *gin.Context) {
 }
 
 func (h *Handler) RestoreDatabase(c *gin.Context) {
+	if h.dbPath == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database path is not configured"})
+		return
+	}
+	// FormFile otherwise permits arbitrarily large multipart requests to be
+	// written to disk, turning an authenticated endpoint into a storage DoS.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRestoreDatabaseBytes)
 	file, err := c.FormFile("database")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "multipart field database is required"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "multipart field database is required and must be <= 128 MiB"})
+		return
+	}
+	if file.Size > maxRestoreDatabaseBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "database backup exceeds 128 MiB limit"})
 		return
 	}
 	f, err := file.Open()
@@ -60,10 +73,6 @@ func (h *Handler) RestoreDatabase(c *gin.Context) {
 		return
 	}
 	defer f.Close()
-	if h.dbPath == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database path is not configured"})
-		return
-	}
 	if err := RestoreDatabase(h.dbPath, f); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -217,6 +217,6 @@ main(){
   say "3m-ui installed successfully."
   say "Command: 3m-ui"
   say "Panel: http://SERVER_IP:8080/"
-  say "The initial administrator password is generated randomly and printed once in the service log; change it immediately."
+  say "Default administrator credentials are unchanged; first login requires a password change."
 }
 main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -123,9 +123,7 @@ install_mihomo(){
 install_release_asset(){
   tag="$1"; file="$2"; destination="$3"
   tmp="$(mktemp)"
-  if download "https://github.com/$REPO/releases/download/${tag}/${file}" "$tmp" 2>/dev/null; then
-    :
-  else
+  if download "https://github.com/$REPO/releases/download/${tag}/${file}" "$tmp" 2>/dev/null; then :; else
     say "Release $tag does not contain $file; using the matching main-branch management script."
     rm -f "$tmp"
     download "https://raw.githubusercontent.com/$REPO/main/scripts/$file" "$tmp"
@@ -219,6 +217,6 @@ main(){
   say "3m-ui installed successfully."
   say "Command: 3m-ui"
   say "Panel: http://SERVER_IP:8080/"
-  say "Default administrator credentials are unchanged; first login requires a password change."
+  say "The initial administrator password is generated randomly and printed once in the service log; change it immediately."
 }
 main "$@"


### PR DESCRIPTION
## Audit scope
- Backend authentication/JWT configuration
- bootstrap administrator lifecycle
- subscription access/info endpoints
- SQLite filesystem permissions
- database restore upload handling
- subconverter response handling
- installer messaging
- existing listener/config validation paths were reviewed for command injection and schema bypasses

## Fixes
- reject default/weak JWT and credential-encryption secrets at startup
- generate a cryptographically random initial admin password when no explicit password is configured
- enforce enabled/non-expired state on public subscription info endpoints
- restrict SQLite directory/database permissions
- cap database restore uploads at 128 MiB
- cap subconverter responses at 16 MiB
- update installer messaging to match the new bootstrap behavior
- add configuration validation tests

The branch is intentionally a draft until CI completes.