### PR TITLE
fix: audit listener rollback, Mihomo apply, and Telegram access control

### DIFF
--- a/backend/internal/listener/service.go
+++ b/backend/internal/listener/service.go
@@ -99,6 +99,11 @@ func (s *Service) Delete(id uint) error {
 	if err := s.SaveVersion(id, "before-delete"); err != nil {
 		return fmt.Errorf("save listener history: %w", err)
 	}
+
+	var bindings []models.ListenerUser
+	if err := s.db.Where("listener_id = ?", id).Find(&bindings).Error; err != nil {
+		return fmt.Errorf("failed to fetch listener bindings: %w", err)
+	}
 	if err := s.db.Where("listener_id = ?", id).Delete(&models.ListenerUser{}).Error; err != nil {
 		return fmt.Errorf("failed to delete listener bindings: %w", err)
 	}
@@ -108,6 +113,11 @@ func (s *Service) Delete(id uint) error {
 	if err := s.regenerateConfigLocked(); err != nil {
 		if rollbackErr := s.db.Unscoped().Save(&previous).Error; rollbackErr != nil {
 			return fmt.Errorf("%v; rollback deleted listener failed: %w", err, rollbackErr)
+		}
+		if len(bindings) > 0 {
+			if restoreErr := s.db.Unscoped().Save(&bindings).Error; restoreErr != nil {
+				return fmt.Errorf("%v; rollback listener bindings failed: %w", err, restoreErr)
+			}
 		}
 		_ = s.regenerateConfigLocked()
 		return err

--- a/backend/internal/mihomo/service.go
+++ b/backend/internal/mihomo/service.go
@@ -30,7 +30,7 @@ func (s *Service) SaveConfig(content string) error {
 
 // ApplyConfig validates and activates a candidate configuration. Before the
 // live file is changed, the current file is copied to <config>.bak. If
-// validation or restart fails, the previous configuration is restored.
+// validation or start/restart fails, the previous configuration is restored.
 func (s *Service) ApplyConfig(content string) error {
 	if s == nil || s.cm == nil { return fmt.Errorf("mihomo service not initialized") }
 	old, readErr := s.cm.ReadConfig()
@@ -45,7 +45,17 @@ func (s *Service) ApplyConfig(content string) error {
 		if readErr == nil { _ = s.cm.SaveConfig(old) }
 		return fmt.Errorf("validate Mihomo configuration: %w", err)
 	}
-	if !wasRunning { return s.pm.Start() }
+	if !wasRunning {
+		if err := s.pm.Start(); err != nil {
+			if readErr == nil {
+				if restoreErr := s.cm.SaveConfig(old); restoreErr != nil {
+					return fmt.Errorf("start Mihomo: %v; restore previous config: %w", err, restoreErr)
+				}
+			}
+			return fmt.Errorf("start Mihomo: %w", err)
+		}
+		return nil
+	}
 	if err := s.pm.Restart(); err != nil {
 		if readErr == nil {
 			if restoreErr := s.cm.SaveConfig(old); restoreErr == nil { _ = s.pm.Restart() }

--- a/backend/internal/protocol/compile.go
+++ b/backend/internal/protocol/compile.go
@@ -135,13 +135,14 @@ func copyConfigPassthrough(dst, cfg map[string]interface{}, skip map[string]stru
 func managedKeys() map[string]struct{} {
 	return map[string]struct{}{
 		"name": {}, "type": {}, "port": {}, "listen": {}, "proxy": {}, "rule": {},
-		"routing-mark": {}, "udp": {}, "tls": {}, "users": {},
+		"routing-mark": {}, "udp": {}, "tls": {}, "users": {}, "flow": {},
 	}
 }
 
 func asUsersArray(cfg map[string]interface{}, fromCreds []UserCred, field string, hasCredState bool) []map[string]interface{} {
+	var out []map[string]interface{}
 	if len(fromCreds) > 0 {
-		out := make([]map[string]interface{}, 0, len(fromCreds))
+		out = make([]map[string]interface{}, 0, len(fromCreds))
 		for _, c := range fromCreds {
 			u := map[string]interface{}{}
 			switch field {
@@ -169,16 +170,23 @@ func asUsersArray(cfg map[string]interface{}, fromCreds []UserCred, field string
 				out = append(out, u)
 			}
 		}
-		return out
+	} else {
+		// Explicit empty credential state must not fall back to config users.
+		if hasCredState {
+			return nil
+		}
+		if raw, ok := cfg["users"]; ok {
+			out = normalizeUsersValue(raw)
+		}
 	}
-	// Explicit empty credential state must not fall back to config users.
-	if hasCredState {
-		return nil
+	if flow, ok := cfg["flow"].(string); ok && strings.TrimSpace(flow) != "" {
+		for _, user := range out {
+			if _, exists := user["flow"]; !exists {
+				user["flow"] = flow
+			}
+		}
 	}
-	if raw, ok := cfg["users"]; ok {
-		return normalizeUsersValue(raw)
-	}
-	return nil
+	return out
 }
 
 func normalizeUsersValue(value interface{}) []map[string]interface{} {

--- a/backend/internal/protocol/compile_listener_test.go
+++ b/backend/internal/protocol/compile_listener_test.go
@@ -1,0 +1,72 @@
+package protocol
+
+import "testing"
+
+func TestVLESSCompilerMovesTopLevelFlowIntoUsers(t *testing.T) {
+	result, err := (VLESSCompiler{}).Compile(CompileInput{
+		Name:     "vless-reality",
+		Protocol: "vless",
+		Listen:   "0.0.0.0",
+		Port:     443,
+		Config: map[string]interface{}{
+			"flow": "xtls-rprx-vision",
+			"reality-config": map[string]interface{}{
+				"dest": "example:443",
+			},
+		},
+		Users: []UserCred{{UUID: "11111111-1111-4111-8111-111111111111"}},
+	})
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if _, ok := result["flow"]; ok {
+		t.Fatal("top-level VLESS flow must not be emitted")
+	}
+	users, ok := result["users"].([]map[string]interface{})
+	if !ok || len(users) != 1 {
+		t.Fatalf("unexpected users: %#v", result["users"])
+	}
+	if users[0]["flow"] != "xtls-rprx-vision" {
+		t.Fatalf("expected user flow, got %#v", users[0]["flow"])
+	}
+}
+
+func TestVLESSCompilerPreservesPerUserFlow(t *testing.T) {
+	result, err := (VLESSCompiler{}).Compile(CompileInput{
+		Name:     "vless",
+		Protocol: "vless",
+		Listen:   "0.0.0.0",
+		Port:     443,
+		Config: map[string]interface{}{
+			"flow": "xtls-rprx-vision",
+		},
+		Users: []UserCred{{UUID: "11111111-1111-4111-8111-111111111111", Flow: ""}},
+	})
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	users := result["users"].([]map[string]interface{})
+	if users[0]["flow"] != "xtls-rprx-vision" {
+		t.Fatalf("expected fallback flow, got %#v", users[0]["flow"])
+	}
+}
+
+func TestVLESSCompilerDoesNotOverrideExplicitUserFlow(t *testing.T) {
+	result, err := (VLESSCompiler{}).Compile(CompileInput{
+		Name:     "vless",
+		Protocol: "vless",
+		Listen:   "0.0.0.0",
+		Port:     443,
+		Config: map[string]interface{}{
+			"flow": "xtls-rprx-vision",
+		},
+		Users: []UserCred{{UUID: "11111111-1111-4111-8111-111111111111", Flow: "custom-flow"}},
+	})
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	users := result["users"].([]map[string]interface{})
+	if users[0]["flow"] != "custom-flow" {
+		t.Fatalf("explicit user flow was overwritten: %#v", users[0]["flow"])
+	}
+}

--- a/backend/internal/telegram/bot.go
+++ b/backend/internal/telegram/bot.go
@@ -178,54 +178,19 @@ func normalizeChatID(id string) string {
 }
 
 func buildAllowedChats(ids []string) map[string]struct{} {
-	allowed := make(map[string]struct{}, len(ids)*4)
-	add := func(v string) {
-		v = normalizeChatID(v)
-		if v == "" {
-			return
-		}
-		allowed[v] = struct{}{}
-	}
+	allowed := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
 		n := normalizeChatID(id)
-		if n == "" {
-			continue
-		}
-		add(n)
-		if strings.HasPrefix(n, "-") {
-			add(strings.TrimPrefix(n, "-"))
-		} else if _, err := strconv.ParseInt(n, 10, 64); err == nil {
-			add("-" + n)
-		}
-		if strings.HasPrefix(n, "-100") {
-			body := strings.TrimPrefix(n, "-100")
-			add(body)
-			add("-" + body)
-		} else if !strings.HasPrefix(n, "-") {
-			if _, err := strconv.ParseInt(n, 10, 64); err == nil {
-				add("-100" + n)
-			}
-		} else if strings.HasPrefix(n, "-") && !strings.HasPrefix(n, "-100") {
-			add("-100" + strings.TrimPrefix(n, "-"))
+		if n != "" {
+			allowed[n] = struct{}{}
 		}
 	}
 	return allowed
 }
 
 func chatAllowed(allowed map[string]struct{}, chatID string) bool {
-	n := normalizeChatID(chatID)
-	if _, ok := allowed[n]; ok {
-		return true
-	}
-	if v, err := strconv.ParseInt(n, 10, 64); err == nil {
-		if _, ok := allowed[strconv.FormatInt(v, 10)]; ok {
-			return true
-		}
-		if _, ok := allowed[strconv.FormatInt(-v, 10)]; ok {
-			return true
-		}
-	}
-	return false
+	_, ok := allowed[normalizeChatID(chatID)]
+	return ok
 }
 
 type tgUpdate struct {

--- a/backend/internal/telegram/bot_security_test.go
+++ b/backend/internal/telegram/bot_security_test.go
@@ -1,0 +1,19 @@
+package telegram
+
+import "testing"
+
+func TestChatAllowlistRequiresExactChatID(t *testing.T) {
+	allowed := buildAllowedChats([]string{"12345", "-10067890"})
+
+	for _, id := range []string{"12345", "-10067890"} {
+		if !chatAllowed(allowed, id) {
+			t.Fatalf("configured chat %q should be allowed", id)
+		}
+	}
+
+	for _, id := range []string{"-12345", "-10012345", "67890", "-67890", "-100123"} {
+		if chatAllowed(allowed, id) {
+			t.Fatalf("unconfigured chat %q must not be allowed", id)
+		}
+	}
+}


### PR DESCRIPTION
## Full-project audit fixes

Audited the backend core, Listener/config generation, Mihomo process/config lifecycle, Telegram command authorization, user credential flow, cluster proxying, backup/restore, and frontend auth handling. Compared Listener protocol semantics with `Tychristine/clashmeta-inbound`.

### Fixed

1. **P0 — VLESS user `flow` could be emitted at the wrong level**
   - Mihomo VLESS Reality/Vision expects `flow` inside `users[]`.
   - Top-level `flow` is now treated as a default and injected into users without an explicit flow.
   - Added regression tests and prevented top-level emission.

2. **P1 — Listener delete rollback lost user bindings**
   - `Delete()` removed `listener_users` before regeneration.
   - If config generation/apply failed, the listener was restored but its bindings were not.
   - The rollback now snapshots and restores the bindings too.

3. **P1 — Mihomo `ApplyConfig()` could leave a new config installed when starting a stopped core failed**
   - When the candidate passed validation but `Start()` failed, the old config was not restored.
   - The old config is now restored on start failure when a previous config existed.

4. **P1 — Telegram chat allowlist alias bypass**
   - The old allowlist converted one configured chat ID into multiple IDs (e.g. `12345`, `-12345`, `-10012345`).
   - Telegram chat IDs are distinct security principals; this could authorize an unconfigured chat.
   - Authorization now requires an exact normalized chat ID.
   - Added a regression test covering user/group/supergroup ID aliases.

### Reference comparison

Checked the Listener capabilities represented by `clashmeta-inbound`, including:
- VLESS Reality + Vision
- VLESS Reality + XHTTP
- VLESS TLS + XHTTP
- Hysteria2
- Hysteria2 pinned certificate
- ShadowQuic

No speculative schema changes were made where the existing 3m-ui implementation already represents the reference fields.

### Verification

Repository CI is configured to run Go format, vet, tests, build, frontend lint/build, and shell syntax checks. I have not claimed local execution where the environment cannot reliably clone the repository.