### PR TITLE
feat(listeners): suggest the first available default node name

### DIFF
--- a/frontend/src/pages/Listeners.tsx
+++ b/frontend/src/pages/Listeners.tsx
@@ -14,6 +14,7 @@ import PageHeader from '../components/PageHeader';
 import useIsMobile from '../hooks/useIsMobile';
 import { copyText } from '../utils/clipboard';
 import { randomListenerPort } from '../utils/listenerPort';
+import { suggestListenerName } from '../utils/listenerName';
 import ListenerConfigFields, { configToFormValues, formValuesToConfig, protocolSupportsUDP } from '../components/ListenerConfigFields';
 import CapabilityFormFields, { capabilityFormToConfig } from '../components/CapabilityFormFields';
 import { fetchCapabilities, protocolCapability, CapabilityManifest } from '../api/capabilities';
@@ -75,7 +76,7 @@ const Listeners: React.FC = () => {
     if (port) form.setFieldsValue({ port });
   };
 
-  const openCreate = () => { setEditing(null); form.resetFields(); form.setFieldsValue({ port: suggestPort(), bind_address: '0.0.0.0', enabled: true, udp: false, protocol: 'vless', transport_layer: 'raw', security_layer: 'reality', reality_enabled: true, client_fingerprint: 'chrome', flow: 'xtls-rprx-vision' }); setModalOpen(true); };
+  const openCreate = () => { setEditing(null); form.resetFields(); form.setFieldsValue({ name: suggestListenerName(data.map((listener) => listener.name)), port: suggestPort(), bind_address: '0.0.0.0', enabled: true, udp: false, protocol: 'vless', transport_layer: 'raw', security_layer: 'reality', reality_enabled: true, client_fingerprint: 'chrome', flow: 'xtls-rprx-vision' }); setModalOpen(true); };
   const openEdit = (record: Listener) => { setEditing(record); form.resetFields(); form.setFieldsValue({ name: record.name, protocol: record.protocol, port: record.port, bind_address: record.bind_address || '0.0.0.0', enabled: record.enabled, udp: record.udp, public_host: (record as any).public_host || '', public_port: (record as any).public_port || '', access_sni: (record as any).access_sni || '', client_fingerprint: (record as any).client_fingerprint || 'chrome', access_alpn: (record as any).access_alpn || '', ...configToFormValues(record.config) }); setModalOpen(true); };
   const onSubmit = async (rawValues?: any) => {
     try {

--- a/frontend/src/utils/listenerName.ts
+++ b/frontend/src/utils/listenerName.ts
@@ -1,0 +1,7 @@
+/** Suggest the first unused listener name, reusing gaps in the sequence. */
+export function suggestListenerName(names: string[]): string {
+  const usedNames = new Set(names.map((name) => name.trim()));
+  let number = 1;
+  while (usedNames.has(`节点${number}`)) number++;
+  return `节点${number}`;
+}


### PR DESCRIPTION
## Summary

- Prefill the listener creation form with the first unused name in the `节点{number}` sequence, starting at 1 and reusing gaps.
- Check all loaded listeners, including disabled entries, independently of the table search filter. Keep the suggested name editable and preserve it when switching protocols.

## Testing

- TypeScript build and Vite production build passed.
- Oxlint completed successfully with existing warnings.
- Five direct naming checks passed: empty list, consecutive names, gaps, custom names and leading zeros, and surrounding whitespace.
- `git diff --check` passed. Code review found no blocking issues.

## Risks

- Suggestions use the currently loaded listener list. Concurrent changes or a stale list can still cause a duplicate-name rejection from the existing backend validation.
- Browser interaction has not been manually verified. The production build retains the existing bundle-size warning.
