### PR TITLE
perf: compress and cache embedded frontend assets

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -105,7 +105,7 @@ func Run(frontendFS fs.FS) error {
 	}
 
 	r := router.SetupRouterWithDeps(container.RouterDeps())
-	mountFrontend(r, frontendFS)
+	router.MountFrontend(r, frontendFS)
 
 	sslSettings, _ := acme.LoadSettings(db)
 	if sslSettings.Enabled {
@@ -190,44 +190,6 @@ func serveWithSSL(handler http.Handler, s acme.Settings, fallbackPort int) error
 
 func defaultConfigPath() string {
 	return config.ConfigPath()
-}
-
-func mountFrontend(r *gin.Engine, frontendFS fs.FS) {
-	staticFS, err := fs.Sub(frontendFS, "web/dist")
-	if err != nil {
-		log.Printf("frontend assets unavailable: %v", err)
-		return
-	}
-	fileServer := http.FileServer(http.FS(staticFS))
-	r.RedirectTrailingSlash = false
-	r.RedirectFixedPath = false
-	r.NoRoute(func(c *gin.Context) {
-		path := c.Request.URL.Path
-		if strings.HasPrefix(path, "/api") {
-			c.Status(http.StatusNotFound)
-			return
-		}
-		if path == "/" {
-			c.Data(http.StatusOK, "text/html; charset=utf-8", mustReadFile(staticFS, "index.html"))
-			return
-		}
-		f, err := staticFS.Open(path[1:])
-		if err == nil {
-			defer f.Close()
-			fileServer.ServeHTTP(c.Writer, c.Request)
-			return
-		}
-		c.Data(http.StatusOK, "text/html; charset=utf-8", mustReadFile(staticFS, "index.html"))
-	})
-}
-
-func mustReadFile(fsys fs.FS, name string) []byte {
-	data, err := fs.ReadFile(fsys, name)
-	if err != nil {
-		log.Printf("read frontend %s failed: %v", name, err)
-		return []byte("3m-ui frontend unavailable")
-	}
-	return data
 }
 
 // panelListenAddr builds a net listen address supporting dual-stack and IPv6.

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -1,7 +1,19 @@
 package router
 
 import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"log"
+	"mime"
 	"net/http"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/kazeyukiro/3m-ui/backend/internal/acme"
@@ -109,4 +121,130 @@ func SetupRouterWithDeps(d Deps) *gin.Engine {
 	}
 
 	return r
+}
+
+var hashedFrontendAsset = regexp.MustCompile(`^assets/.+-[A-Za-z0-9_-]{8,}\.(js|css)$`)
+
+type frontendAsset struct {
+	data, compressed                                []byte
+	contentType, etag, compressedETag, cacheControl string
+}
+
+// MountFrontend serves embedded assets independently of API/subscription routes.
+// Compression happens once at startup, not on the request path or on disk.
+func MountFrontend(r *gin.Engine, frontendFS fs.FS) {
+	staticFS, err := fs.Sub(frontendFS, "web/dist")
+	if err != nil {
+		log.Printf("frontend assets unavailable: %v", err)
+		return
+	}
+	assets := make(map[string]frontendAsset)
+	err = fs.WalkDir(staticFS, ".", func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		data, err := fs.ReadFile(staticFS, name)
+		if err != nil {
+			return err
+		}
+		contentType := mime.TypeByExtension(path.Ext(name))
+		if contentType == "" {
+			contentType = http.DetectContentType(data)
+		}
+		asset := frontendAsset{data: data, contentType: contentType, etag: fmt.Sprintf(`"%x"`, sha256.Sum256(data)), cacheControl: "no-cache"}
+		if hashedFrontendAsset.MatchString(name) {
+			asset.cacheControl = "public, max-age=31536000, immutable"
+		}
+		if len(data) >= 1024 && (strings.HasPrefix(contentType, "text/") || strings.Contains(contentType, "javascript") || strings.Contains(contentType, "json") || strings.Contains(contentType, "svg+xml")) {
+			var buffer bytes.Buffer
+			writer := gzip.NewWriter(&buffer)
+			if _, err := writer.Write(data); err != nil {
+				return err
+			}
+			if err := writer.Close(); err != nil {
+				return err
+			}
+			if buffer.Len() < len(data) {
+				asset.compressed = buffer.Bytes()
+				asset.compressedETag = fmt.Sprintf(`"%x"`, sha256.Sum256(asset.compressed))
+			}
+		}
+		assets[name] = asset
+		return nil
+	})
+	if err != nil {
+		log.Printf("frontend assets unavailable: %v", err)
+		return
+	}
+	if _, ok := assets["index.html"]; !ok {
+		log.Printf("frontend index.html unavailable")
+		return
+	}
+	r.RedirectTrailingSlash = false
+	r.RedirectFixedPath = false
+	r.NoRoute(func(c *gin.Context) {
+		requestPath := c.Request.URL.Path
+		if strings.HasPrefix(requestPath, "/api") || (c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		name := strings.TrimPrefix(requestPath, "/")
+		asset, ok := assets[name]
+		if !ok {
+			// Missing chunks must never return cacheable HTML after a deployment.
+			if strings.HasPrefix(requestPath, "/assets/") || requestPath == "/assets" {
+				c.Header("Cache-Control", "no-store")
+				c.Status(http.StatusNotFound)
+				return
+			}
+			name, asset = "index.html", assets["index.html"]
+		}
+		data, etag := asset.data, asset.etag
+		if asset.compressed != nil {
+			c.Writer.Header().Add("Vary", "Accept-Encoding")
+			// Keep byte ranges in the identity representation; ServeContent handles
+			// Range, If-Range, conditional requests and HEAD consistently.
+			if c.Request.Header.Get("Range") == "" && acceptsFrontendGzip(c.Request.Header.Values("Accept-Encoding")) {
+				data = asset.compressed
+				etag = asset.compressedETag
+				c.Header("Content-Encoding", "gzip")
+			}
+		}
+		c.Header("Content-Type", asset.contentType)
+		c.Header("Cache-Control", asset.cacheControl)
+		c.Header("ETag", etag)
+		http.ServeContent(c.Writer, c.Request, name, time.Time{}, bytes.NewReader(data))
+	})
+}
+
+func acceptsFrontendGzip(values []string) bool {
+	wildcard := false
+	for _, item := range strings.Split(strings.Join(values, ","), ",") {
+		parts := strings.Split(item, ";")
+		coding := strings.ToLower(strings.TrimSpace(parts[0]))
+		if coding != "gzip" && coding != "*" {
+			continue
+		}
+		quality := 1.0
+		for _, parameter := range parts[1:] {
+			key, value, ok := strings.Cut(strings.TrimSpace(parameter), "=")
+			if ok && strings.EqualFold(strings.TrimSpace(key), "q") {
+				parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+				if err != nil || parsed < 0 || parsed > 1 {
+					quality = 0
+				} else {
+					quality = parsed
+				}
+			}
+		}
+		// An explicit refusal overrides the wildcard regardless of ordering.
+		if coding == "gzip" {
+			return quality > 0
+		}
+		wildcard = quality > 0
+	}
+	return wildcard
 }

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -1,11 +1,17 @@
 package router_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/kazeyukiro/3m-ui/backend/internal/auth"
 	"github.com/kazeyukiro/3m-ui/backend/internal/config"
@@ -139,6 +145,120 @@ func TestCORSConfiguredOrigin(t *testing.T) {
 	r.ServeHTTP(w2, req2)
 	if got := w2.Header().Get("Access-Control-Allow-Origin"); got != "" {
 		t.Fatalf("expected no allow-origin for disallowed origin, got %q", got)
+	}
+}
+
+func TestFrontendCompressionAndCaching(t *testing.T) {
+	script := []byte(strings.Repeat("console.log('frontend asset');\n", 4096))
+	html := []byte("<!doctype html>" + strings.Repeat("<p>Application</p>", 100))
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Header("Vary", "Origin"); c.Next() })
+	r.GET("/api/v1/health", func(c *gin.Context) { c.JSON(200, gin.H{"status": "ok"}) })
+	router.MountFrontend(r, fstest.MapFS{
+		"web/dist/index.html":                &fstest.MapFile{Data: html},
+		"web/dist/assets/index-Abcd123_.js":  &fstest.MapFile{Data: script},
+		"web/dist/assets/style-Abcd123_.css": &fstest.MapFile{Data: []byte("body{color:red}")},
+		"web/dist/logo.svg":                  &fstest.MapFile{Data: []byte("<svg></svg>")},
+		"web/dist/manifest.webmanifest":      &fstest.MapFile{Data: []byte(`{"name":"3m-ui"}`)},
+	})
+	request := func(method, path string, headers map[string]string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, path, nil)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		out := httptest.NewRecorder()
+		r.ServeHTTP(out, req)
+		return out
+	}
+	const url = "/assets/index-Abcd123_.js"
+	plain := request("GET", url, nil)
+	if plain.Code != 200 || !bytes.Equal(plain.Body.Bytes(), script) || plain.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("identity response: %d %v", plain.Code, plain.Header())
+	}
+	if plain.Header().Get("Cache-Control") != "public, max-age=31536000, immutable" {
+		t.Fatal(plain.Header())
+	}
+	compressed := request("GET", url, map[string]string{"Accept-Encoding": "gzip"})
+	if compressed.Code != 200 || compressed.Header().Get("Content-Encoding") != "gzip" || compressed.Body.Len() >= len(script)/4 {
+		t.Fatalf("compression: %d %v", compressed.Code, compressed.Header())
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(compressed.Body.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := io.ReadAll(reader)
+	reader.Close()
+	if err != nil || !bytes.Equal(decoded, script) {
+		t.Fatal("compressed content differs")
+	}
+	if compressed.Header().Get("Content-Type") != plain.Header().Get("Content-Type") {
+		t.Fatal("compressed MIME type changed")
+	}
+	vary := strings.Join(compressed.Header().Values("Vary"), ",")
+	if !strings.Contains(vary, "Origin") || !strings.Contains(vary, "Accept-Encoding") {
+		t.Fatal(vary)
+	}
+	etag, gzipETag := plain.Header().Get("ETag"), compressed.Header().Get("ETag")
+	if etag == "" || gzipETag == "" || etag == gzipETag {
+		t.Fatal("missing representation-specific validators")
+	}
+	for _, tc := range []struct {
+		encoding, tag string
+		status        int
+	}{
+		{"identity", etag, 304}, {"gzip", gzipETag, 304}, {"gzip", etag, 200}, {"identity", gzipETag, 200},
+	} {
+		result := request("GET", url, map[string]string{"Accept-Encoding": tc.encoding, "If-None-Match": tc.tag})
+		if result.Code != tc.status || (tc.status == 304 && result.Body.Len() != 0) {
+			t.Fatalf("conditional %v: %d", tc, result.Code)
+		}
+	}
+	for _, tc := range []struct {
+		encoding   string
+		compressed bool
+	}{
+		{"gzip", true}, {"br, gzip;q=0.5", true}, {"GZIP", true}, {"*", true},
+		{"gzip;q=0", false}, {"*;q=1, gzip;q=0", false}, {"gzip;q=0, *;q=1", false},
+		{"br", false}, {"gzip;q=invalid", false}, {"gzip;q=1.5", false},
+	} {
+		result := request("GET", url, map[string]string{"Accept-Encoding": tc.encoding})
+		if (result.Header().Get("Content-Encoding") == "gzip") != tc.compressed {
+			t.Fatalf("encoding %q: %v", tc.encoding, result.Header())
+		}
+	}
+	head := request("HEAD", url, map[string]string{"Accept-Encoding": "gzip"})
+	if head.Code != 200 || head.Body.Len() != 0 || head.Header().Get("Content-Length") != compressed.Header().Get("Content-Length") {
+		t.Fatalf("HEAD: %v", head)
+	}
+	partial := request("GET", url, map[string]string{"Accept-Encoding": "gzip", "Range": "bytes=0-9", "If-Range": etag})
+	if partial.Code != 206 || partial.Header().Get("Content-Encoding") != "" || !bytes.Equal(partial.Body.Bytes(), script[:10]) {
+		t.Fatalf("range: %v", partial)
+	}
+	for _, path := range []string{"/", "/index.html", "/core"} {
+		result := request("GET", path, nil)
+		if result.Code != 200 || !bytes.Equal(result.Body.Bytes(), html) || result.Header().Get("Cache-Control") != "no-cache" {
+			t.Fatalf("HTML %s: %v", path, result)
+		}
+		cached := request("GET", path, map[string]string{"If-None-Match": result.Header().Get("ETag")})
+		if cached.Code != 304 {
+			t.Fatalf("HTML revalidation %s: %d", path, cached.Code)
+		}
+	}
+	for _, path := range []string{"/assets/missing-12345678.js", "/assets", "/api/missing"} {
+		result := request("GET", path, nil)
+		if result.Code != 404 || bytes.Contains(result.Body.Bytes(), html) || strings.Contains(result.Header().Get("Cache-Control"), "immutable") {
+			t.Fatalf("missing %s: %v", path, result)
+		}
+	}
+	for _, path := range []string{"/logo.svg", "/manifest.webmanifest"} {
+		result := request("GET", path, nil)
+		if result.Code != 200 || result.Header().Get("Cache-Control") != "no-cache" {
+			t.Fatalf("unhashed %s: %v", path, result)
+		}
+	}
+	health := request("GET", "/api/v1/health", map[string]string{"Accept-Encoding": "gzip"})
+	if health.Code != 200 || health.Header().Get("Cache-Control") != "" || health.Header().Get("Content-Encoding") != "" {
+		t.Fatal("static policy leaked onto API")
 	}
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -183,3 +183,13 @@ The Core page supports manual updates and rollback of official stable and Pre Mi
 versions on Linux amd64/arm64. Selected versions persist in the existing data
 volume across panel upgrades. See [core updates](core-updates.md) for validation,
 recovery, and deployment integration details.
+
+## Frontend compression and caching
+
+The panel precompresses embedded text assets with gzip once at startup and serves
+compressed responses when the client accepts them. Hashed JavaScript and CSS
+assets use `Cache-Control: public, max-age=31536000, immutable`; HTML and assets
+without content hashes use `no-cache` with ETags so new deployments are detected.
+Identity and gzip responses have separate validators and use `Vary: Accept-Encoding`.
+No reverse-proxy compression setting or writable asset directory is required.
+Missing `/assets/` files return an uncached 404 rather than the SPA HTML fallback.


### PR DESCRIPTION
Precompress embedded frontend assets with gzip and cache hashed JS/CSS for one year. Revalidate HTML with ETags so deployments stay fresh.

### Validation

Verified deployment of `deceb7c` to https://3m-1.gouway.com/:

| Check | Result |
| --- | --- |
| Main JS transfer | 2,146,843 → 572,631 bytes (**73.3% smaller**) |
| Hashed JS/CSS caching | `public, max-age=31536000, immutable` |
| HTML freshness | `no-cache` with ETag revalidation |
| Conditional requests | HTML, JS, and CSS return **304** with no response body |

- Backend tests (default and `sqlite_modernc`), race checks, 10 frontend unit tests, production build, and isolated Linux container tests passed.
- Gzip integrity, HEAD/range requests, missing-asset 404s, and public login checks passed. Account/configuration fingerprints were preserved; Mihomo remains `v1.19.29` with `v1.19.30` available for rollback.
