### PR TITLE
style(go): format backend sources

### DIFF
--- a/backend/internal/listener/service.go
+++ b/backend/internal/listener/service.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/kazeyukiro/3m-ui/backend/internal/database/models"
 	dbconfig "github.com/kazeyukiro/3m-ui/backend/internal/mihomo/config"
@@ -21,13 +21,13 @@ type Service struct {
 		ApplyConfig(string) error
 		ApplyConfigDeferredRestart(string) error
 	}
-	mu          sync.Mutex
+	mu sync.Mutex
 }
 
 func NewService(db *gorm.DB, configPath string, mihomoApply interface {
-		ApplyConfig(string) error
-		ApplyConfigDeferredRestart(string) error
-	}) *Service {
+	ApplyConfig(string) error
+	ApplyConfigDeferredRestart(string) error
+}) *Service {
 	return &Service{db: db, configPath: configPath, mihomoApply: mihomoApply}
 }
 

--- a/backend/internal/mihomo/service.go
+++ b/backend/internal/mihomo/service.go
@@ -202,7 +202,6 @@ func (s *Service) ApplyConfig(content string) error {
 	return nil
 }
 
-
 // ApplyConfigDeferredRestart writes and validates the config like ApplyConfig, but
 // restarts Mihomo in the background after a successful validation. Used by panel
 // create/update/delete so the HTTP handler can return before a multi-second restart.

--- a/backend/internal/subpage/render.go
+++ b/backend/internal/subpage/render.go
@@ -298,7 +298,6 @@ func localSubQRDataURI(subURL string) template.URL {
 	return template.URL("data:image/png;base64," + base64.StdEncoding.EncodeToString(png))
 }
 
-
 func protocolLabel(uri string) string {
 	uri = strings.TrimSpace(uri)
 	if i := strings.Index(uri, "://"); i > 0 {

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -21,9 +21,9 @@ type Service struct {
 	// Async reload: ApplyConfig validates + restarts Mihomo and can take longer
 	// than the browser's HTTP timeout. Blocking the create/delete handler caused
 	// false "Cannot reach the panel API" errors even when the DB write succeeded.
-	credMu       sync.Mutex
-	credTimer    *time.Timer
-	credPending  bool
+	credMu      sync.Mutex
+	credTimer   *time.Timer
+	credPending bool
 }
 
 func NewService(db *gorm.DB) *Service {


### PR DESCRIPTION
Run gofmt on the four backend files rejected by the CI format check. No behavior changes.

Validation: repository-wide gofmt check, go vet, and git diff --check pass. The existing asynchronous credential test failures are handled in #56.
