### PR TITLE
fix(listener): serialize configuration generation and application

### DIFF
--- a/backend/internal/listener/service.go
+++ b/backend/internal/listener/service.go
@@ -215,15 +215,11 @@ func (s *Service) ensureEndpointAvailable(candidate *models.Listener) error {
 }
 
 func (s *Service) RegenerateConfig() error {
-	// Generate under the service lock, then ApplyConfig outside so concurrent
-	// read APIs are not blocked for the whole Mihomo validate+restart window.
+	// Keep generation and application ordered with listener mutations so an old
+	// snapshot cannot overwrite the configuration from a newer Create/Update/Delete.
 	s.mu.Lock()
-	yamlContent, err := s.generateConfigYAMLLocked()
-	s.mu.Unlock()
-	if err != nil {
-		return err
-	}
-	return s.applyGeneratedYAML(yamlContent)
+	defer s.mu.Unlock()
+	return s.regenerateConfigLocked()
 }
 
 func (s *Service) regenerateConfigLocked() error {

--- a/backend/internal/listener/service_concurrency_test.go
+++ b/backend/internal/listener/service_concurrency_test.go
@@ -1,0 +1,97 @@
+package listener
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kazeyukiro/3m-ui/backend/internal/database"
+	"github.com/kazeyukiro/3m-ui/backend/internal/database/models"
+)
+
+type orderedConfigApplier struct {
+	mu      sync.Mutex
+	calls   int
+	configs []string
+	started chan struct{}
+	resume  chan struct{}
+}
+
+func (a *orderedConfigApplier) ApplyConfig(content string) error {
+	a.mu.Lock()
+	a.calls++
+	first := a.calls == 1
+	a.mu.Unlock()
+	if first {
+		close(a.started)
+		<-a.resume
+	}
+	a.mu.Lock()
+	a.configs = append(a.configs, content)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *orderedConfigApplier) ApplyConfigDeferredRestart(content string) error {
+	return a.ApplyConfig(content)
+}
+
+func TestRegenerationCannotOverwriteConcurrentListenerCreate(t *testing.T) {
+	db, err := database.InitDB(filepath.Join(t.TempDir(), "panel.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := db.DB()
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	applier := &orderedConfigApplier{started: make(chan struct{}), resume: make(chan struct{})}
+	resume := sync.OnceFunc(func() { close(applier.resume) })
+	t.Cleanup(resume)
+	svc := NewService(db, "unused.yaml", applier)
+	regenerated := make(chan error, 1)
+	go func() { regenerated <- svc.RegenerateConfig() }()
+	select {
+	case <-applier.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("configuration generation did not reach the applier")
+	}
+	listener := &models.Listener{Name: "new-listener", Protocol: "shadowsocks", Port: "19388", BindAddress: "127.0.0.1", Enabled: true, Config: `{"cipher":"aes-128-gcm","password":"test-password"}`}
+	created := make(chan error, 1)
+	go func() { created <- svc.Create(listener) }()
+	var createErr error
+	completedEarly := false
+	select {
+	case createErr = <-created:
+		completedEarly = true
+		t.Error("listener creation overtook the pending configuration application")
+	case <-time.After(250 * time.Millisecond):
+	}
+	resume()
+	select {
+	case err := <-regenerated:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("configuration application did not finish")
+	}
+	if !completedEarly {
+		select {
+		case createErr = <-created:
+		case <-time.After(5 * time.Second):
+			t.Fatal("listener creation did not finish")
+		}
+	}
+	if createErr != nil {
+		t.Fatal(createErr)
+	}
+	if _, err := svc.GetByID(listener.ID); err != nil {
+		t.Fatal(err)
+	}
+	applier.mu.Lock()
+	defer applier.mu.Unlock()
+	if len(applier.configs) != 2 || !strings.Contains(applier.configs[len(applier.configs)-1], listener.Name) {
+		t.Fatal("the final configuration lost the successfully created listener")
+	}
+}


### PR DESCRIPTION
Keep configuration generation and application ordered with listener mutations so an older background reload cannot overwrite a newly created listener.

Validation: listener package tests and the concurrency regression pass, including the race detector. The regression fails against the original implementation. Baseline CI failures are addressed in #55 (formatting) and #56 (credential tests).
