### PR TITLE
fix(listener): roll back mutations when core activation fails

### DIFF
--- a/backend/internal/listener/runtime_test.go
+++ b/backend/internal/listener/runtime_test.go
@@ -66,9 +66,6 @@ type recordingRuntimeInspector struct{ details []bool }
 func (r *recordingRuntimeInspector) ApplyConfig(string) error {
 	return nil
 }
-func (r *recordingRuntimeInspector) ApplyConfigDeferredRestart(string) error {
-	return nil
-}
 func (r *recordingRuntimeInspector) ListenerRuntime(listeners []models.Listener, details bool) []mihomo.ListenerRuntime {
 	r.details = append(r.details, details)
 	results := make([]mihomo.ListenerRuntime, len(listeners))

--- a/backend/internal/listener/service.go
+++ b/backend/internal/listener/service.go
@@ -19,14 +19,12 @@ type Service struct {
 	configPath  string
 	mihomoApply interface {
 		ApplyConfig(string) error
-		ApplyConfigDeferredRestart(string) error
 	}
 	mu          sync.Mutex
 }
 
 func NewService(db *gorm.DB, configPath string, mihomoApply interface {
 		ApplyConfig(string) error
-		ApplyConfigDeferredRestart(string) error
 	}) *Service {
 	return &Service{db: db, configPath: configPath, mihomoApply: mihomoApply}
 }
@@ -252,13 +250,7 @@ func (s *Service) generateConfigYAMLLocked() (string, error) {
 
 func (s *Service) applyGeneratedYAML(yamlContent string) error {
 	if s.mihomoApply != nil {
-		// Prefer deferred restart so create/delete HTTP handlers return after
-		// validation instead of blocking on a full core restart (often >30s).
-		if d, ok := s.mihomoApply.(interface {
-			ApplyConfigDeferredRestart(string) error
-		}); ok {
-			return d.ApplyConfigDeferredRestart(yamlContent)
-		}
+		// Report activation failures while CRUD can still restore the database.
 		return s.mihomoApply.ApplyConfig(yamlContent)
 	}
 	dir := filepath.Dir(s.configPath)

--- a/backend/internal/listener/service_activation_test.go
+++ b/backend/internal/listener/service_activation_test.go
@@ -1,0 +1,89 @@
+package listener
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kazeyukiro/3m-ui/backend/internal/config"
+	"github.com/kazeyukiro/3m-ui/backend/internal/database"
+	"github.com/kazeyukiro/3m-ui/backend/internal/database/models"
+	"github.com/kazeyukiro/3m-ui/backend/internal/mihomo"
+)
+
+func TestListenerMutationsRestoreDatabaseAfterActivationFailure(t *testing.T) {
+	for _, operation := range []string{"create", "update", "delete"} {
+		t.Run(operation, func(t *testing.T) {
+			dir, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(mihomo.AllowBinaryPathPrefixForTesting(dir))
+			binary := filepath.Join(dir, "fixture-core")
+			// Validation succeeds, but the next process start fails. The old
+			// configuration can then be restarted, exercising the rollback path.
+			script := "#!/bin/sh\ncase \"$1\" in\n-v) echo 'Mihomo v1.0.0'; exit 0;;\n-t) exit 0;;\nesac\nif [ -f \"$2/reject-next-start\" ]; then\n  rm \"$2/reject-next-start\"\n  echo 'fixture: runtime initialization failed' >&2\n  exit 1\nfi\nexec sleep 60\n"
+			if err := os.WriteFile(binary, []byte(script), 0700); err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(configPath, []byte("listeners: []\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			core := mihomo.NewService(&config.Config{Mihomo: config.MihomoConfig{Binary: binary, Config: configPath}})
+			if err := core.StartMihomo(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = core.StopMihomo() })
+			db, err := database.InitDB(filepath.Join(dir, "panel.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			sqlDB, _ := db.DB()
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			svc := NewService(db, configPath, core)
+			candidate := &models.Listener{Name: "test-listener", Protocol: "shadowsocks", Port: "19389", BindAddress: "127.0.0.1", Config: `{"cipher":"aes-128-gcm","password":"test-password"}`}
+			if operation != "create" {
+				if err := db.Create(candidate).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(dir, "reject-next-start"), nil, 0600); err != nil {
+				t.Fatal(err)
+			}
+			switch operation {
+			case "create":
+				candidate.Enabled = true
+				err = svc.Create(candidate)
+			case "update":
+				candidate.Enabled = true
+				err = svc.Update(candidate)
+			case "delete":
+				err = svc.Delete(candidate.ID)
+			}
+			if err == nil {
+				t.Fatal("mutation reported success despite the failed core activation")
+			}
+			var remaining []models.Listener
+			if err := db.Find(&remaining).Error; err != nil {
+				t.Fatal(err)
+			}
+			if operation == "create" {
+				if len(remaining) != 0 {
+					t.Fatal("failed creation left a listener in the database")
+				}
+			} else if len(remaining) != 1 || remaining[0].ID != candidate.ID || remaining[0].Name != candidate.Name || remaining[0].Enabled {
+				t.Fatalf("previous listener was not restored: %+v", remaining)
+			}
+			content, err := os.ReadFile(configPath)
+			if err != nil || strings.Contains(string(content), candidate.Name) {
+				t.Fatalf("runtime configuration did not restore the disabled/absent listener: %v", err)
+			}
+			status, err := core.GetStatus()
+			if err != nil || !status.Running {
+				t.Fatalf("previous core did not recover: status=%+v err=%v", status, err)
+			}
+		})
+	}
+}

--- a/backend/internal/mihomo/service.go
+++ b/backend/internal/mihomo/service.go
@@ -3,7 +3,6 @@ package mihomo
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -199,93 +198,6 @@ func (s *Service) ApplyConfig(content string) error {
 		}
 		return fmt.Errorf("apply Mihomo configuration: %w", err)
 	}
-	return nil
-}
-
-
-// ApplyConfigDeferredRestart writes and validates the config like ApplyConfig, but
-// restarts Mihomo in the background after a successful validation. Used by panel
-// create/update/delete so the HTTP handler can return before a multi-second restart.
-// If validation fails, the previous config is restored and the error is returned
-// synchronously (same safety as ApplyConfig).
-func (s *Service) ApplyConfigDeferredRestart(content string) error {
-	if s == nil || s.cm == nil {
-		return fmt.Errorf("mihomo service not initialized")
-	}
-	if err := s.coreMutationAllowed(); err != nil {
-		return err
-	}
-	s.applyMu.Lock()
-	if err := s.coreMutationAllowed(); err != nil {
-		s.applyMu.Unlock()
-		return err
-	}
-	old, readErr := s.cm.ReadConfig()
-	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) && !os.IsNotExist(readErr) {
-		s.applyMu.Unlock()
-		return fmt.Errorf("read current Mihomo config: %w", readErr)
-	}
-	if readErr == nil {
-		if err := os.WriteFile(s.cm.configPath+".bak", []byte(old), 0600); err != nil {
-			s.applyMu.Unlock()
-			return fmt.Errorf("backup Mihomo config: %w", err)
-		}
-	}
-	if err := s.cm.SaveConfig(content); err != nil {
-		s.applyMu.Unlock()
-		return err
-	}
-	if s.pm == nil {
-		s.applyMu.Unlock()
-		return nil
-	}
-	if err := s.pm.ValidateConfig(); err != nil {
-		if readErr == nil {
-			_ = s.cm.SaveConfig(old)
-		} else {
-			_ = os.Remove(s.cm.configPath)
-		}
-		s.applyMu.Unlock()
-		return fmt.Errorf("validate Mihomo configuration: %w", err)
-	}
-	wasRunning := s.pm.IsRunning()
-	// First start must be synchronous: callers (smoke tests, UI after create) expect
-	// mihomo/status.running == true as soon as the listener API returns.
-	if !wasRunning {
-		err := s.startAndCheckListeners(content, false)
-		if err != nil {
-			_ = s.pm.Stop()
-			if readErr == nil {
-				_ = s.cm.SaveConfig(old)
-			} else {
-				_ = os.Remove(s.cm.configPath)
-			}
-			s.applyMu.Unlock()
-			return fmt.Errorf("start Mihomo: %w", err)
-		}
-		s.applyMu.Unlock()
-		return nil
-	}
-
-	// Core already running: restart in the background so HTTP create/update is not
-	// blocked for the full validate+restart window. Config on disk is already valid.
-	s.applyMu.Unlock()
-	go func() {
-		s.applyMu.Lock()
-		defer s.applyMu.Unlock()
-		if err := s.startAndCheckListeners(content, true); err != nil {
-			log.Printf("warning: Mihomo restart after config apply failed: %v", err)
-			if readErr == nil {
-				if restoreErr := s.cm.SaveConfig(old); restoreErr != nil {
-					log.Printf("warning: restore previous Mihomo config failed: %v", restoreErr)
-					return
-				}
-				if restartErr := s.startAndCheckListeners(string(old), true); restartErr != nil {
-					log.Printf("warning: restart previous Mihomo config failed: %v", restartErr)
-				}
-			}
-		}
-	}()
 	return nil
 }
 


### PR DESCRIPTION
Wait for core activation before confirming listener mutations, allowing the existing rollback paths to restore the database and configuration after a restart failure. Remove the deferred restart path; listener saves now wait for activation.

Validation: create/update/delete failure regressions pass under the race detector, with database, config, and process recovery checks. Listener, node, and router tests pass. The regressions fail against the original implementation. Baseline CI failures are addressed in #55 (formatting) and #56 (credential tests).
