### PR TITLE
fix(api): apply mutation request timeout defaults

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,8 +3,9 @@ import { useAuthStore } from '../stores/authStore';
 
 const client = axios.create({
   baseURL: '/api/v1',
-  // GET polls stay moderate; mutating endpoints raise timeout in the request interceptor.
-  timeout: 45000,
+  // Resolve the default after Axios merges request options. A null sentinel
+  // preserves explicit timeouts, including 0 (no timeout).
+  timeout: null,
   headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
 });
 
@@ -14,9 +15,8 @@ client.interceptors.request.use((config: InternalAxiosRequestConfig) => {
     config.headers.Authorization = `Bearer ${token}`;
   }
   const method = (config.method || 'get').toLowerCase();
-  if (method !== 'get' && method !== 'head' && config.timeout == null) {
-    // Listener create/delete runs Mihomo validate+restart on the request path.
-    config.timeout = 120000;
+  if (config.timeout == null) {
+    config.timeout = method === 'get' || method === 'head' ? 45000 : 120000;
   }
   return config;
 });

--- a/frontend/src/utils/apiTimeout.test.mjs
+++ b/frontend/src/utils/apiTimeout.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import vm from 'node:vm';
+import ts from 'typescript';
+
+const require = createRequire(import.meta.url);
+const source = fs.readFileSync(new URL('../api/client.ts', import.meta.url), 'utf8');
+const javascript = ts.transpileModule(source, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS, esModuleInterop: true },
+}).outputText;
+
+function panelClient() {
+  const module = { exports: {} };
+  vm.runInNewContext(javascript, {
+    module, exports: module.exports,
+    require: name => name === '../stores/authStore'
+      ? { useAuthStore: { getState: () => ({ token: null }) } }
+      : require(name),
+  });
+  const client = module.exports.default;
+  // Observe the effective timeout after real Axios merging and interceptors.
+  client.defaults.adapter = async config => ({
+    data: config.timeout, status: 200, statusText: 'OK', headers: {}, config,
+  });
+  return client;
+}
+
+test('read requests default to 45 seconds and mutations default to 120 seconds', async () => {
+  const client = panelClient();
+  for (const method of ['get', 'head', 'post', 'put', 'patch', 'delete']) {
+    const response = await client.request({ method, url: '/nodes' });
+    assert.equal(response.data, method === 'get' || method === 'head' ? 45000 : 120000, method);
+  }
+});
+
+test('explicit request timeouts survive defaults and request interceptors', async () => {
+  const client = panelClient();
+  for (const method of ['get', 'post', 'delete']) {
+    for (const timeout of [0, 25000, 40000, 45000, 120000, 180000]) {
+      const response = await client.request({ method, url: '/nodes', timeout });
+      assert.equal(response.data, timeout, `${method} with timeout ${timeout}`);
+    }
+  }
+});


### PR DESCRIPTION
Resolve default timeouts after Axios merges request options: 45 seconds for GET/HEAD and 120 seconds for mutations. Preserve explicit overrides, including zero for no timeout.

Validation: all 12 frontend tests and the production build pass. Tests exercise real Axios merging and interceptors; the mutation default regression fails against the original client. Baseline CI failures are addressed in #55 (formatting) and #56 (credential tests).
